### PR TITLE
fix：修复横滑组件在快速滚动时的闪动

### DIFF
--- a/src/components/swipe-action/index.js
+++ b/src/components/swipe-action/index.js
@@ -127,6 +127,9 @@ export default class AtSwipeAction extends AtComponent {
     const { offsetSize } = this.state
     const { options } = this.props
     const rootClass = classNames('at-swipe-action', this.props.className)
+    const transformStyle = offsetSize > -20 ? {} : {
+      transform: `translate3d(${offsetSize}px,0,0)`
+    }
 
     return (
       <View
@@ -139,9 +142,7 @@ export default class AtSwipeAction extends AtComponent {
           className={classNames('at-swipe-action__content', {
             animtion: !this.isTouching
           })}
-          style={{
-            transform: `translate3d(${offsetSize}px,0,0)`
-          }}
+          style={transformStyle}
         >
           {this.props.children}
         </View>


### PR DESCRIPTION
## 问题现象

iOS真机下，多个带有操作入口的横滑组件（AtSwipeAction）在快速上下滑动时，会闪现即将进入页面的横滑组件的操作入口。

## 问题定位

iOS真机下，对view组件设置`transform: translate3d(0,0,0)`的样式，会导致view组件出现闪现情况。

## 问题修复

在没有横向拖动的交互时，不设置`transform`样式，为了保证上下滚动时尽量不要频繁出发横滑，将偏移量的敏感值设置为20