### PR TITLE
fix(icon): 修复 size 未跟随配置转换为 rpx

### DIFF
--- a/src/components/icon/index.js
+++ b/src/components/icon/index.js
@@ -52,7 +52,7 @@ export default class AtIcon extends AtComponent {
     } = this.props
 
     const rootStyle = {
-      fontSize: `${size}px`,
+      fontSize: `${Taro.pxTransform(size)}`,
       color
     }
 


### PR DESCRIPTION
修复 #112 