### PR TITLE
fix the AtTabs bug when the tabList API passes an empty array

### DIFF
--- a/src/components/tabs/index.js
+++ b/src/components/tabs/index.js
@@ -43,7 +43,7 @@ export default class AtTabs extends AtComponent {
         case Taro.ENV_TYPE.WEB: {
           const index = Math.max(idx - 1, 0)
           const prevTabItem = this.tabHeaderRef.childNodes[index]
-          this.setState({
+          prevTabItem && this.setState({
             _scrollTop: prevTabItem.offsetTop,
             _scrollLeft: prevTabItem.offsetLeft
           })


### PR DESCRIPTION
When the tabList API passes an empty array(for example, when initializing asynchronous requests for data on a page，the tabList will be received an  empty array ),the browser will throw an error:
```
 Uncaught (in promise) TypeError: Cannot read property 'offsetTop' of undefined
```
I have solved this errorand hope to adopt it.