### PR TITLE
fix(tabs): 修复右滑返回上一页触发滑动页面的 bug

### DIFF
--- a/src/components/tabs/index.js
+++ b/src/components/tabs/index.js
@@ -85,7 +85,7 @@ export default class AtTabs extends AtComponent {
     const moveDistance = touchMove - this._touchDot
     const maxIndex = tabList.length
 
-    if (!this._isMoving && this._interval < MAX_INTERVAL) {
+    if (!this._isMoving && this._interval < MAX_INTERVAL && this._touchDot > 20) {
       // 向左滑动
       if (current + 1 < maxIndex && moveDistance <= -MIN_DISTANCE) {
         this._isMoving = true


### PR DESCRIPTION
手势返回上一页的时候，判断下原点的位置，如果离屏幕左边的距离太近当做是滑动返回上一页