### PR TITLE
fix(swipe-action): 阻止滑动触发默认行为

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "lint": "eslint ./src --fix",
     "lint:style": "stylelint \"src/**/*.scss\" --syntax scss",
     "lint:style-fix": "stylelint \"src/**/*.scss\" --syntax scss --fix",
-    "test": "NODE_ENV=test && jest --coverage",
+    "test": "cross-env NODE_ENV=test && jest --coverage",
     "test:ci": "npm run build:h5 && npm run test",
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s -r 1"
   },

--- a/src/components/swipe-action/index.js
+++ b/src/components/swipe-action/index.js
@@ -113,6 +113,8 @@ export default class AtSwipeAction extends AtComponent {
   }
 
   handleTouchMove = e => {
+    e.preventDefault()
+
     if (_isEmpty(this.domInfo)) {
       return
     }


### PR DESCRIPTION
**修复问题**

1. 滑动swipe-action组件时，阻止默认行为
2. windows下运行`npm run test`会报错`NODE_ENV`

**说明**

swipe-action组件具有左右滑动的操作
在手机上很多浏览器都是默认会开启 **左滑返回上一页**
这就导致了组件的滑动与浏览器默认行为冲突，想要左滑隐藏swipe-action组件的操作按钮，却返回了上一页。
