### PR TITLE
fix(tab-bar): 修复 TypeScript 中 TabItem 没有 image/ selectedImage 属性报错

### DIFF
--- a/@types/tab-bar.d.ts
+++ b/@types/tab-bar.d.ts
@@ -11,6 +11,8 @@ export interface TabItem {
   iconPrefixClass?: string
   iconType?: string
   selectedIconType?: string
+  image?: string
+  selectedImage?: string
 }
 
 export interface AtTabBarProps extends AtComponent{


### PR DESCRIPTION
**修复问题**

在 TypeScript 项目中使用 Tab 组件的 image/ selectedImage 属性出现 `'image' does not exist in type 'TabItem'` 的问题

**说明**

在 @types/tab-bar.d.ts 描述文件中添加了对应的类型声明