### PR TITLE
fix(tabbar): 修复 tabbar 中 props参数名称错误的问题

### DIFF
--- a/src/components/tab-bar/index.js
+++ b/src/components/tab-bar/index.js
@@ -78,7 +78,7 @@ export default class AtTabBar extends AtComponent {
             onClick={this.handleClick.bind(this, i)}
           >
             {item.iconType ? (
-              <AtBadge dot={!!item.dot} value={item.text} max={item.max}>
+              <AtBadge dot={!!item.dot} value={item.text} maxValue={item.max}>
                 <View className='at-tab-bar__icon'>
                   <Text className={classNames(`${item.iconPrefixClass || 'at-icon'}`, {
                     [`${item.iconPrefixClass || 'at-icon'}-${item.selectedIconType}`]: current === i && item.selectedIconType,
@@ -93,7 +93,7 @@ export default class AtTabBar extends AtComponent {
             ) : null}
 
             {item.image ? (
-              <AtBadge dot={!!item.dot} value={item.text} max={item.max}>
+              <AtBadge dot={!!item.dot} value={item.text} maxValue={item.max}>
                 <View className='at-tab-bar__icon'>
                   <Image
                     className={classNames(
@@ -123,7 +123,7 @@ export default class AtTabBar extends AtComponent {
               <AtBadge
                 dot={(item.iconType || item.image) ? false : !!item.dot}
                 value={(item.iconType || item.image) ? '' : item.text}
-                max={(item.iconType || item.image) ? '' : item.max}
+                maxValue={(item.iconType || item.image) ? '' : item.max}
               >
                 <View className='at-tab-bar__title' style={titleStyle}>
                   {item.title}


### PR DESCRIPTION
- [badge](https://github.com/NervJS/taro-ui/blob/dev/src/components/badge/index.js#L27) 组件中接收的 props 参数为 `maxValue`
- [tabbar](https://github.com/NervJS/taro-ui/blob/dev/src/components/tab-bar/index.js#L126) 组件使用 badge 组件，传入的 props 却为 `max`