### PR TITLE
Fix component calendar

### DIFF
--- a/src/components/calendar/common/plugins.ts
+++ b/src/components/calendar/common/plugins.ts
@@ -1,5 +1,5 @@
 import dayjs from 'dayjs'
-import _isEmpty from 'lodash/isEmpty'
+import _isArray from 'lodash/isArray'
 
 import Calendar from '../types'
 
@@ -111,7 +111,7 @@ export function handleValid (
   const { _value } = item
   const { validDates } = options
 
-  if (!_isEmpty(validDates)) {
+  if (_isArray(validDates)) {
     const isInclude = validDates.some(date => {
       return dayjs(date.value).startOf('day').isSame(_value)
     })

--- a/src/components/calendar/index.tsx
+++ b/src/components/calendar/index.tsx
@@ -123,6 +123,18 @@ export default class AtCalendar extends Taro.Component<Props, Readonly<State>> {
     let start: number
     let generateDateValue: number
 
+    if (!currentDate) {
+      const dayjsStart = dayjs()
+      start = dayjsStart.startOf('day').valueOf()
+      generateDateValue = dayjsStart.startOf('month').valueOf()
+      return {
+        generateDate: generateDateValue,
+        selectedDate: {
+          start: ''
+        }
+      }
+    }
+
     if (isMultiSelect) {
       const { start: cStart, end: cEnd } = currentDate as Calendar.SelectedDate
 

--- a/src/components/calendar/interface.ts
+++ b/src/components/calendar/interface.ts
@@ -3,6 +3,8 @@ import Calendar from './types'
 export interface PropsBase {
   format?: string
 
+  validDates?: Array<Calendar.ValidDate>
+
   minDate?: Calendar.DateArg
 
   maxDate?: Calendar.DateArg


### PR DESCRIPTION
- validDates 类型声明缺失
- 允许 validDates 设置为空数组时，无法选中任何日期
- 允许 currentDate 设置为空时，默认不选中当前日