### PR TITLE
feat(search-bar): add input placeholder

### DIFF
--- a/src/components/search-bar/index.js
+++ b/src/components/search-bar/index.js
@@ -8,21 +8,28 @@ class AtSearchBar extends AtComponent {
   constructor (props) {
     super(...arguments)
     this.state = {
+      inputPlaceholder: props.focus && props.placeholder ? props.placeholder : '',
       isFocus: props.focus
     }
   }
 
   handleFocus = (...arg) => {
+    const { placeholder, onFocus } = this.props
+
     this.setState({
-      isFocus: true
+      isFocus: true,
+      inputPlaceholder: placeholder,
     })
-    this.props.onFocus(...arg)
+
+    onFocus && onFocus(...arg)
   }
 
   handleBlur = (...arg) => {
     this.setState({
-      isFocus: false
+      isFocus: false,
+      inputPlaceholder: '',
     })
+
     this.props.onBlur(...arg)
   }
 
@@ -53,7 +60,7 @@ class AtSearchBar extends AtComponent {
       className,
       customStyle
     } = this.props
-    const { isFocus } = this.state
+    const { isFocus, inputPlaceholder } = this.state
     const fontSize = 14
     const rootCls = classNames(
       'at-search-bar',
@@ -111,6 +118,7 @@ class AtSearchBar extends AtComponent {
             focus={focus}
             disabled={disabled}
             maxLength={maxLength}
+            placeholder={inputPlaceholder}
             onInput={this.handleChange}
             onFocus={this.handleFocus}
             onBlur={this.handleBlur}


### PR DESCRIPTION
来源: [searchbar 组件的实现有问题](https://github.com/NervJS/taro-ui/issues/462)

当时的处理是，当聚焦的时候，会把 placeholder 值切换为空字符来避免这种情况，但是这样的处理会导致当组件默认聚焦的时候，placeholder 直接就看不见了，使得用户体验很怪异，也失去了 placeholder 作为辅助描述功能的作用。