### PR TITLE
fix(calendar): 修复没有指定 validDates 时没有日期可选

### DIFF
--- a/src/components/calendar/index.tsx
+++ b/src/components/calendar/index.tsx
@@ -17,7 +17,6 @@ import AtCalendarController from './controller/index'
 import { DefaultProps, Props, State, PropsWithDefaults } from './interface'
 
 const defaultProps: DefaultProps = {
-  validDates: [],
   marks: [],
   isSwiper: true,
   hideArrow: false,


### PR DESCRIPTION
validDates 修改前默认为空数组，按照现在设定空数组将没有可选日期。去除默认值以修复这个问题
相关 pr #599