### PR TITLE
修改AtTabBar内调用AtBadge默认参数传递有误问题

### DIFF
--- a/src/components/tab-bar/index.js
+++ b/src/components/tab-bar/index.js
@@ -122,8 +122,8 @@ export default class AtTabBar extends AtComponent {
             <View>
               <AtBadge
                 dot={(item.iconType || item.image) ? false : !!item.dot}
-                value={(item.iconType || item.image) ? '' : item.text}
-                maxValue={(item.iconType || item.image) ? '' : item.max}
+                value={item.text ? item.text : ''}
+                maxValue={item.max ? item.max : 99}
               >
                 <View className='at-tab-bar__title' style={titleStyle}>
                   {item.title}


### PR DESCRIPTION
原默认值为空字符串，在tabList不传递max的情况下会警告：Invalid prop `maxValue` of type `string` supplied to `AtBadge`, expected `number`.  并完善三目判断