### PR TITLE
fix(tabbar): 修复AtTabBar内调用AtBadge，提示类型错误

### DIFF
--- a/src/components/tab-bar/index.js
+++ b/src/components/tab-bar/index.js
@@ -122,8 +122,8 @@ export default class AtTabBar extends AtComponent {
             <View>
               <AtBadge
                 dot={(item.iconType || item.image) ? false : !!item.dot}
-                value={(item.iconType || item.image) ? '' : item.text}
-                maxValue={(item.iconType || item.image) ? '' : item.max}
+                value={(item.iconType || item.image) ? null : item.text}
+                maxValue={(item.iconType || item.image) ? null : item.max}
               >
                 <View className='at-tab-bar__title' style={titleStyle}>
                   {item.title}


### PR DESCRIPTION
使用以下代码：提示错误类型
`<AtTabBar fixed tabList={[ {title: '自定义图标', iconPrefixClass: 'fa-icon', iconType: 'a'}, {title: '拍照', iconType: 'camera'}, {title: '文件夹', iconType: 'folder', text: '100', max: 99} ]} onClick={this.handleClick.bind(this)} current={this.state.current} />`
信息信息
`Failed prop type: Invalid prop maxValueof typestringsupplied toAtBadge, expected number.`

查看代码后发现，AtTabBar在调用AtBadge时传入一个空字符，引发的。
```
value={(item.iconType || item.image) ? null : item.text}
maxValue={(item.iconType || item.image) ? '' : item.max}
```

现我修改以上判断后正常

```
value={(item.iconType || item.image) ? null : item.text}
maxValue={(item.iconType || item.image) ? null : item.max}
```

pr #671 