### PR TITLE
Divider 添加自定义背景色

### DIFF
--- a/src/components/divider/index.js
+++ b/src/components/divider/index.js
@@ -20,7 +20,7 @@ export default class AtDivider extends AtComponent {
       height,
       fontColor,
       fontSize,
-      backgroundColor
+      backgroundColor,
       lineColor,
     } = this.props
 

--- a/src/components/divider/index.js
+++ b/src/components/divider/index.js
@@ -20,6 +20,7 @@ export default class AtDivider extends AtComponent {
       height,
       fontColor,
       fontSize,
+      backgroundColor
       lineColor,
     } = this.props
 
@@ -32,6 +33,10 @@ export default class AtDivider extends AtComponent {
       'font-size': fontSize ? `${Taro.pxTransform(fontSize)}` : ''
     }
 
+    const backgroundStyle = {
+      'background-color': backgroundColor
+    }
+
     const lineStyle = {
       'background-color': lineColor
     }
@@ -41,7 +46,7 @@ export default class AtDivider extends AtComponent {
         className={classNames('at-divider', className)}
         style={this.mergeStyle(rootStyle, customStyle)}
       >
-        <View className='at-divider__content' style={fontStyle}>
+        <View className='at-divider__content' style={this.mergeStyle(fontStyle, backgroundStyle)}>
           {content === '' ? this.props.children : content}
         </View>
         <View className='at-divider__line' style={lineStyle}></View>


### PR DESCRIPTION
at-divider__content 目前永远都是 #fff 色，如果 page 背景不是白色的时候，就尴尬了