### PR TITLE
Update toast.d.ts

### DIFF
--- a/@types/toast.d.ts
+++ b/@types/toast.d.ts
@@ -12,7 +12,7 @@ export interface AtToastProps extends AtComponent{
 
   image?: string
 
-  status?: 'error' | 'loading' | 'success'
+  status?: 'error' | 'loading' | 'success' | string
 
   duration?: number
 


### PR DESCRIPTION
```
const [status,setStatus]=Taro.useState('scuccess')
<AtToast status={status} />

```
不能将类型“string”分配给类型“"error" | "loading" | "success" | undefined”。