### PR TITLE
fix(Calendar):修复日历组件在切换月份时出现的样式错乱问题

### DIFF
--- a/src/components/calendar/ui/date-list/index.tsx
+++ b/src/components/calendar/ui/date-list/index.tsx
@@ -42,8 +42,10 @@ export default class AtCalendarList extends Taro.Component<Props> {
 
     if (!list || list.length === 0) return null
 
+    const updateFlag = list[0].value
+
     return (
-      <View className='at-calendar__list flex'>
+      <View className='at-calendar__list flex' key={updateFlag}>
         {list.map((item) => (
           <View
             key={item.text}


### PR DESCRIPTION
【修复思路】
暂时还没有想到更好的解决办法，目前先打算用props key来强制渲染