### PR TITLE
fix: model content 在显示长文本时会溢出’

### DIFF
--- a/src/style/components/modal.scss
+++ b/src/style/components/modal.scss
@@ -49,7 +49,8 @@ $at-modal-duration: 200ms;
     max-height: 840px;
     color: $at-modal-content-text-color;
     font-size: $font-size-base;
-    box-sizing: border-box;
+    box-sizing: content-box;
+    width: auto;
   }
 
   &__footer {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/22094785/75047469-c401c500-5501-11ea-99f6-3994a831c6a6.png)
当前状态下， 显示长文本出溢出。现已修复， 修复效果如下。

![image](https://user-images.githubusercontent.com/22094785/75047417-b0565e80-5501-11ea-9b3f-88d3bd6633c8.png)
