### PR TITLE
fix(accordion): Accordion组件默认开启的状态时 state wrapperHeight 初始设置为0会导致动画错误

### DIFF
--- a/src/components/accordion/index.tsx
+++ b/src/components/accordion/index.tsx
@@ -25,7 +25,7 @@ export default class AtAccordion extends AtComponent<
     this.isCompleted = true
     this.startOpen = false
     this.state = {
-      wrapperHeight: 0
+      wrapperHeight: 'unset'
     }
   }
 
@@ -109,8 +109,9 @@ export default class AtAccordion extends AtComponent<
       color: (icon && icon.color) || '',
       fontSize: (icon && `${icon.size}px`) || ''
     }
-    const contentStyle = { height: `${wrapperHeight}px` }
-
+    const contentStyle = {
+      height: wrapperHeight === 'unset' ? wrapperHeight : `${wrapperHeight}px`
+    }
     if (this.isCompleted) {
       contentStyle.height = ''
     }

--- a/types/accordion.d.ts
+++ b/types/accordion.d.ts
@@ -40,7 +40,7 @@ export interface AtAccordionProps extends AtComponent {
 }
 
 export interface AtAccordionState {
-  wrapperHeight: number
+  wrapperHeight: number | 'unset'
 }
 
 declare const AtAccordion: ComponentClass<AtAccordionProps>


### PR DESCRIPTION
wrapperHeight默认值 0时，toggleWithAnimation设置startHeight时 会导致css3错误触发动画；现在的示例第二个就有这个问题：https://taro-ui.jd.com/#/docs/accordion 。
fix: 将组件的state wrapperHeight 默认值设置为 ’unset‘，可以防止toggleWithAnimation方法设置初始高度是错误的出现动画。
希望采纳，或者用更优雅的方式解决下，谢谢