### PR TITLE
支持输入 0. ，用isNaN判断非法输入

### DIFF
--- a/src/components/input-number/index.tsx
+++ b/src/components/input-number/index.tsx
@@ -97,7 +97,7 @@ export default class AtInputNumber extends AtComponent<AtInputNumberProps> {
         errorValue: resultValue!
       })
     }
-    if (resultValue && !Number(resultValue)) {
+    if (resultValue && isNaN(resultValue)) {
       resultValue = parseFloat(String(resultValue)) || min
 
       this.handleError({


### PR DESCRIPTION
直接用isNaN 来判断非法输入，!Number( ) 在输入 0. 的时候为true，导致被处理为0，用户无法输入0.xxx一类的小数