### PR TITLE
fix(float-layout): 修改是否垂直滚动的默认值为false

### DIFF
--- a/src/components/float-layout/index.tsx
+++ b/src/components/float-layout/index.tsx
@@ -119,7 +119,7 @@ AtFloatLayout.defaultProps = {
   title: '',
   isOpened: false,
 
-  scrollY: true,
+  scrollY: false,
   scrollX: false,
   scrollWithAnimation: false,
 

--- a/types/float-layout.d.ts
+++ b/types/float-layout.d.ts
@@ -16,7 +16,7 @@ export interface AtFloatLayoutProps extends AtComponent {
   title?: string
   /**
    * 是否垂直滚动
-   * @default true
+   * @default false
    */
   scrollY?: boolean
   /**


### PR DESCRIPTION
float-layout组件是否垂直滚动的默认值官网文档上写的是false，代码中实际上为true，修改为和水平方向的一致