### PR TITLE
feat(ellipsis): add ellipsis component and demo

### DIFF
--- a/packages/taro-ui-demo/src/app.config.ts
+++ b/packages/taro-ui-demo/src/app.config.ts
@@ -53,7 +53,8 @@ export default {
     'pages/form/image-picker/index',
     'pages/form/range/index',
     'pages/advanced/calendar/index',
-    'pages/theme/index'
+    'pages/theme/index',
+    'pages/advanced/ellipsis/index'
   ],
   window: {
     backgroundTextStyle: 'light',

--- a/packages/taro-ui-demo/src/pages/advanced/ellipsis/index.tsx
+++ b/packages/taro-ui-demo/src/pages/advanced/ellipsis/index.tsx
@@ -1,0 +1,89 @@
+import React from 'react'
+import { View, Text } from '@tarojs/components'
+import Taro from '@tarojs/taro'
+import { AtEllipsis } from 'taro-ui'
+import DocsHeader from '../../components/doc-header'
+
+export default class Index extends React.Component {
+  public constructor(props: any) {
+    super(props)
+    this.state = {}
+  }
+
+  public config: Taro.PageConfig = {
+    navigationBarTitleText: 'Taro UI CG'
+  }
+
+  public render(): JSX.Element {
+    return (
+      <View className='page'>
+        {/* S Header */}
+        <DocsHeader title='Ellipsis 省略器'></DocsHeader>
+        {/* E Header */}
+
+        {/* S Body */}
+        <View className='doc-body'>
+          {/* Radio */}
+          <View className='panel'>
+            <View className='panel__title'>Normal</View>
+            <View className='panel__content no-padding'>
+              <View className='radio-container'>
+                <AtEllipsis lines={2}>
+                  啊啊及发家史覅氨,,,
+                  <Text style='color: orange'>基酸覅健身房f奥</Text>
+                  术大师大所大所多奥术大师大所大按实际嗲圣诞节爱神的箭加斯安抚基酸覅健身房奥术大师大所大所多奥术大师大所大按实际嗲圣诞节爱神的箭加斯安抚
+                </AtEllipsis>
+              </View>
+            </View>
+          </View>
+
+          <View className='panel'>
+            <View className='panel__title'>展开/收起</View>
+            <View
+              className='panel__content no-padding'
+              style={{ width: '200px' }}
+            >
+              <AtEllipsis
+                text='啊啊及发家史覅氨,,,基酸覅健身房奥术大师大所大所多奥术大师大所大按实际嗲圣诞节爱神的箭加斯安抚基酸覅健身房奥术大师大所大所多奥术大师大所大按实际嗲圣诞节爱神的箭加斯安抚'
+                textStyle={{
+                  fontSize: 28
+                }}
+                btnText='全部展开全部'
+                expand
+                lines={2}
+              />
+            </View>
+          </View>
+
+          <View className='panel'>
+            <View className='panel__title'>自定义</View>
+            <View
+              className='panel__content no-padding'
+              style={{ width: '100px' }}
+            >
+              <AtEllipsis
+                text='啊啊及发家史覅氨,,,基酸覅健身房奥术大师大所大所多奥术大师大所大按实际嗲圣诞节爱神的箭加斯安抚基酸覅健身房奥术大师大所大所多奥术大师大所大按实际嗲圣诞节爱神的箭加斯安抚'
+                textStyle={{
+                  fontSize: 28
+                }}
+                btnText='查看全部'
+                btnTextStyle={{
+                  color: 'red'
+                }}
+                onWillExpand={(text: any): boolean => {
+                  Taro.showModal({
+                    title: text
+                  })
+                  return false
+                }}
+                expand
+                lines={2}
+              />
+            </View>
+          </View>
+        </View>
+        {/* E Body */}
+      </View>
+    )
+  }
+}

--- a/packages/taro-ui-demo/src/pages/panel/index.tsx
+++ b/packages/taro-ui-demo/src/pages/panel/index.tsx
@@ -282,6 +282,10 @@ export default class PanelBasic extends React.Component<{}, PanelBasicState> {
           {
             id: 'Calendar',
             name: '日历'
+          },
+          {
+            id: 'Ellipsis',
+            name: '省略器'
           }
         ]
       },

--- a/packages/taro-ui/src/components/ellipsis/index.tsx
+++ b/packages/taro-ui/src/components/ellipsis/index.tsx
@@ -1,0 +1,255 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+import classNames from 'classnames'
+import PropTypes, { InferProps } from 'prop-types'
+import { AtEllipsisProps, AtEllipsisState } from '../../../types/ellipsis'
+import { View, Canvas } from '@tarojs/components'
+import React from 'react'
+import Taro from '@tarojs/taro'
+import {
+  delayQuerySelector,
+  isTest,
+  uuid,
+  pxTransform
+} from '../../common/utils'
+
+const ENV = Taro.getEnv()
+
+const DEFAULT_FONT_SIZE = 28
+const DEFAULT_TEXT_COLOR = '#646A73'
+const DEFAULT_BTN_COLOR = '#9CA2A9'
+
+const PLACEHOLDER = 'XXX'
+
+const isWEB = Taro.getEnv() === Taro.ENV_TYPE.WEB
+
+const RADIO = isWEB
+  ? window.document.body.clientWidth / 750
+  : Taro.getSystemInfoSync().windowWidth / 750
+
+export default class AtEllipsis extends React.Component<
+  AtEllipsisProps,
+  AtEllipsisState
+> {
+  public static defaultProps: AtEllipsisProps
+  public static propTypes: InferProps<AtEllipsisProps>
+  id: string
+  constructor(props: AtEllipsisProps) {
+    super(props)
+
+    this.id = isTest() ? 'indexes-ellipsis-AOTU2018' : `ellipsis-${uuid()}`
+    this.state = {
+      texts: [],
+      isMore: false,
+      isExpand: !!props.expand
+    }
+
+    this.onSwitch = this.onSwitch.bind(this)
+  }
+
+  public componentDidMount(): void {
+    setTimeout(() => {
+      this.initData()
+    }, 500)
+  }
+
+  private initData(): void {
+    if (isWEB) {
+      const elem = document.querySelector(`#${this.id}`)
+      if (!elem) return
+      const width = elem.getBoundingClientRect().width
+      this.createCanvas({ width })
+      return
+    }
+    delayQuerySelector(`#${this.id}`).then(rect => {
+      this.createCanvas(rect[0])
+    })
+  }
+
+  private createCanvas({ width }): void {
+    let context
+    let canvas
+    if (isWEB) {
+      canvas = document.createElement('canvas')
+      document.body.appendChild(canvas)
+      if (!canvas) return
+      context = canvas.getContext('2d')
+    } else {
+      context = Taro.createCanvasContext('canvas')
+    }
+
+    const { text = '', btnText, lines, textStyle = {} } = this.props
+
+    const fontSize = Math.floor(parseInt(`${textStyle.fontSize}`) * RADIO)
+
+    isWEB
+      ? (context.font = `${fontSize}px Arial`)
+      : context.setFontSize(fontSize)
+    const chr = text.split('')
+
+    const row: Array<string> = []
+    let temp = ''
+    let isMore = false
+    for (let i = 0; i < chr.length; i++) {
+      if (row.length === lines) {
+        isMore = true
+        temp = ''
+        break
+      }
+      let t = temp
+      if (row.length + 1 === lines) {
+        t += `${PLACEHOLDER}${btnText}`
+      }
+      if (context.measureText(t + chr[i]).width < width && chr[i] !== '\\n') {
+        temp += chr[i]
+      } else {
+        row.push(temp)
+        temp = chr[i]
+      }
+    }
+    temp && row.push(temp)
+    isMore && (row[row.length - 1] = `${row[row.length - 1]}...`)
+
+    if (isWEB) {
+      document.body.removeChild(canvas)
+    }
+    this.setState({
+      texts: row,
+      isMore
+    })
+  }
+
+  private onSwitch(): void {
+    const {
+      onExpand = (): void => {},
+      onWillExpand = (): void => {},
+      onWillCollapse = (): void => {},
+      onCollapse = (): void => {}
+    } = this.props
+    const originExpand = this.state.isExpand
+    if (originExpand) {
+      const willExpand = onWillExpand(this.props.text)
+
+      if (typeof willExpand === 'boolean' && willExpand === false) return
+      this.setState(
+        {
+          isExpand: !originExpand
+        },
+        () => {
+          onExpand()
+        }
+      )
+    } else {
+      onWillCollapse()
+
+      this.setState(
+        {
+          isExpand: !originExpand
+        },
+        () => {
+          onCollapse()
+        }
+      )
+    }
+  }
+
+  public render(): JSX.Element {
+    const {
+      text,
+      lines,
+      btnText,
+      expandText,
+      textStyle = {},
+      btnTextStyle = {}
+    } = this.props
+    const { texts, isMore, isExpand } = this.state
+    textStyle.fontSize = pxTransform(+(textStyle.fontSize || DEFAULT_FONT_SIZE))
+    textStyle.color = textStyle.color || DEFAULT_TEXT_COLOR
+    btnTextStyle.fontSize = pxTransform(
+      +(btnTextStyle.fontSize || DEFAULT_FONT_SIZE)
+    )
+    btnTextStyle.color = btnTextStyle.color || DEFAULT_BTN_COLOR
+    // const tStyle = { fontSize: textFont, color: textColor }
+    // const bStyle = { fontSize: btnFont, color: btnColor }
+    const rootClass = classNames({
+      'at-ellipsis': true,
+      [`at-ellipsis--${ENV}`]: true,
+      'at-ellipsis--lineclamp': lines
+    })
+
+    if (text) {
+      return (
+        <View>
+          <Canvas
+            canvasId='canvas'
+            style={{
+              position: 'fixed',
+              left: '-1000px',
+              top: '-1000px',
+              width: '100%',
+              height: '100%'
+            }}
+          />
+          <View id={this.id} className={rootClass} onClick={this.onSwitch}>
+            <View className='at-ellipsis__block' style={{ ...textStyle }}>
+              {text}
+            </View>
+            {isExpand &&
+              texts.map(t => (
+                <View className='at-ellipsis__text' key={t} style={textStyle}>
+                  {t}
+                </View>
+              ))}
+            {!isExpand && <View style={textStyle}>{text}</View>}
+            {isMore && (
+              <View className='at-ellipsis__btn' style={btnTextStyle}>
+                {isExpand ? btnText : expandText}
+              </View>
+            )}
+          </View>
+        </View>
+      )
+    }
+
+    return (
+      <View
+        id={this.id}
+        className={rootClass}
+        style={{
+          // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+          // @ts-ignorets
+          '-webkit-line-clamp': `${lines}`,
+          ...textStyle
+        }}
+      >
+        {this.props.children}
+      </View>
+    )
+  }
+}
+
+AtEllipsis.defaultProps = {
+  text: '',
+  btnText: '全部',
+  expandText: '',
+  textStyle: {},
+  btnTextStyle: {},
+  expand: false,
+  onWillExpand: (): void => {},
+  onWillCollapse: (): void => {},
+  onExpand: (): void => {},
+  onCollapse: (): void => {}
+}
+
+AtEllipsis.propTypes = {
+  text: PropTypes.string,
+  btnText: PropTypes.string,
+  expandText: PropTypes.string,
+  textStyle: PropTypes.object,
+  lines: PropTypes.number,
+  expand: PropTypes.bool,
+  btnTextStyle: PropTypes.object,
+  onWillExpand: PropTypes.func,
+  onWillCollapse: PropTypes.func,
+  onExpand: PropTypes.func,
+  onCollapse: PropTypes.func
+}

--- a/packages/taro-ui/src/index.ts
+++ b/packages/taro-ui/src/index.ts
@@ -49,6 +49,7 @@ export { default as AtRange } from './components/range'
 export { default as AtIndexes } from './components/indexes'
 export { default as AtCalendar } from './components/calendar'
 export { default as AtFab } from './components/fab'
+export { default as AtEllipsis } from './components/ellipsis'
 
 /* 私有的组件  */
 export { default as AtLoading } from './components/loading'

--- a/packages/taro-ui/src/style/components/ellipsis.scss
+++ b/packages/taro-ui/src/style/components/ellipsis.scss
@@ -1,0 +1,30 @@
+
+.at-ellipsis {
+  display: inline-block;
+  width: 100%;
+  overflow: hidden;
+  word-break: break-all;
+  -webkit-box-orient: vertical;
+  line-height: $line-height-zh;
+  font-size: $at-ellipsis-text-font-size;
+  color: $at-ellipsis-text-color;
+
+  &__block { 
+    visibility: hidden;
+    height: 0;
+  }
+  &__btn {
+    position: absolute;
+    padding: 0 $spacing-h-sm;
+    right: 0;
+    bottom: 0;
+    background: rgba(255, 255, 255, 0.8);
+  }
+
+  &--lineclamp {
+    position: relative;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: -webkit-box;
+  }
+}

--- a/packages/taro-ui/src/style/components/index.scss
+++ b/packages/taro-ui/src/style/components/index.scss
@@ -50,3 +50,4 @@
 @import './textarea.scss';
 @import './timeline.scss';
 @import './toast.scss';
+@import './ellipsis.scss';

--- a/packages/taro-ui/src/style/variables/default.scss
+++ b/packages/taro-ui/src/style/variables/default.scss
@@ -455,3 +455,7 @@ $at-timeline-dot-size: 24px !default;
 $at-timeline-dot-color: $color-bg !default;
 $at-timeline-dot-border-color: $color-brand-light !default;
 $at-timeline-line-color: $color-border-lighter !default;
+
+/* Ellipsis */
+$at-ellipsis-text-color: #646A73;
+$at-ellipsis-text-font-size: $font-size-base;

--- a/packages/taro-ui/types/ellipsis.d.ts
+++ b/packages/taro-ui/types/ellipsis.d.ts
@@ -1,0 +1,27 @@
+import { ComponentClass } from 'react'
+import AtComponent from './base'
+
+export interface AtEllipsisProps extends AtComponent {
+  text: string
+  btnText?: string
+  expand?: boolean
+  lines?: number
+  expandText?: string
+  textStyle?: { fontSize?: number | string; color?: string }
+  btnTextStyle?: { fontSize?: number | string; color?: string }
+
+  onWillExpand?: (text?: string) => boolean | void
+  onWillCollapse?: () => void
+  onExpand?: () => void
+  onCollapse?: () => void
+}
+
+export interface AtEllipsisState {
+  texts: Array<string>
+  isExpand: boolean
+  isMore: boolean
+}
+
+declare const AtEllipsis: ComponentClass<HbEllipsisProps>
+
+export default AtEllipsis

--- a/packages/taro-ui/types/index.d.ts
+++ b/packages/taro-ui/types/index.d.ts
@@ -47,6 +47,7 @@ export { default as AtImagePicker } from './image-picker'
 export { default as AtIndexes } from './indexes'
 export { default as AtRange } from './range'
 export { default as AtFloatButton } from './float-button'
+export { default as AtEllipsis } from './ellipsis'
 
 export declare const AtCalendar: ComponentClass<Props>
 


### PR DESCRIPTION
### 添加Ellipsis省略器组件
**两种方式:**
- 提供 props of `text`, 将会使用canvas计算每行显示的文字个数, 并在右下角出现 `全部` 按钮, 点击可以切换 `展开/收起`
- 提供 props.children, 将只会单纯利用样式控制文字的超出隐藏