### PR TITLE
feat(ellipsis): 添加Ellipsis省略器组件

### DIFF
--- a/docs/markdown/ellipsis.md
+++ b/docs/markdown/ellipsis.md
@@ -1,0 +1,151 @@
+# Ellipsis 文本自动省略号
+
+---
+文本自动省略号组件
+
+## 使用指南
+
+在 Taro 文件中引入组件
+
+:::demo
+```js
+import { AtEllipsis } from 'taro-ui'
+```
+:::
+
+**组件依赖的样式文件（仅按需引用时需要）**
+
+:::demo
+```scss
+@import "~taro-ui/dist/style/components/ellipsis.scss";
+```
+:::
+
+## 一般用法
+
+:::demo
+
+```js
+import Taro from '@tarojs/taro'
+import { AtEllipsis }  from 'taro-ui'
+export default class Index extends Taro.Component {
+  constructor () {
+    super(...arguments)
+    this.state = {}
+  }
+
+  render () {
+    return (
+     <AtEllipsis lines={2}>
+        啊啊及发家史覅氨,,,
+        <Text style='color: orange'>基酸覅健身房f奥</Text>
+        术大师大所大所多奥术大师大所大按实际嗲圣诞节爱神的箭加斯安抚基酸覅健身房奥术大师大所大所多奥术大师大所大按实际嗲圣诞节爱神的箭加斯安抚
+      </AtEllipsis>
+    )
+  }
+}
+
+```
+
+:::
+
+## 展开/收起
+
+说明：
+
+* 因为小程序的限制, 要展示 展开/收起 按钮的情况下, 只能通过`text`参数传入文本内容
+* 若要以弹窗等自定义形式显示全部文本, 可以通过`onWillExpand`事件返回false来处理
+
+:::demo
+
+```js
+import Taro from '@tarojs/taro'
+import { AtEllipsis }  from 'taro-ui'
+export default class Index extends Taro.Component {
+  constructor () {
+    super(...arguments)
+    this.state = {}
+  }
+
+  render () {
+    return (
+     <AtEllipsis
+        text='啊啊及发家史覅氨,,,基酸覅健身房奥术大师大所大所多奥术大师大所大按实际嗲圣诞节爱神的箭加斯安抚基酸覅健身房奥术大师大所大所多奥术大师大所大按实际嗲圣诞节爱神的箭加斯安抚'
+        textStyle={{
+          fontSize: 12
+        }}
+        btnText='全部展开全部'
+        expand
+        lines={2}
+      />
+    )
+  }
+}
+
+```
+
+:::demo
+```js
+import Taro from '@tarojs/taro'
+import { AtEllipsis }  from 'taro-ui'
+export default class Index extends Taro.Component {
+  constructor () {
+    super(...arguments)
+    this.state = {}
+  }
+
+  render () {
+    return (
+     <AtEllipsis
+        text='啊啊及发家史覅氨,,,基酸覅健身房奥术大师大所大所多奥术大师大所大按实际嗲圣诞节爱神的箭加斯安抚基酸覅健身房奥术大师大所大所多奥术大师大所大按实际嗲圣诞节爱神的箭加斯安抚'
+        textStyle={{
+          fontSize: 12
+        }}
+        btnText='查看全部'
+        btnTextStyle={{
+          color: 'red'
+        }}
+        onWillExpand={text => {
+          Taro.showModal({
+            title: text
+          })
+          return false
+        }}
+        expand
+        lines={2}
+      />
+    )
+  }
+}
+
+```
+
+:::
+
+## 参数
+
+| 参数       | 说明                                   | 类型    | 可选值                                                              | 默认值   |
+| ---------- | -------------------------------------- | ------- | ------------------------------------------------------------------- | -------- |
+| text | 文本`传入该属性时将会有 展开 按钮`   | String  | - | '' |
+| btnText  | 展开按钮名称  | String | - | '全部' |
+| lines  | 在按照行数截取下最大的行数，超过则截取省略	  | number | - | undefined |
+| expand  | 是否展开文本(该属性对children无效)  | Boolean | - | undefined |
+| textStyle  | 文本text的样式	  | Object | - | 详见下 style object |
+| btnTextStyle  | 按钮btnText的样式	  | Object | - | 详见下 style object |
+
+
+## style object 字段详解
+
+| 参数       | 说明                                   | 类型    | 可选值                                                              | 默认值   | 可选或必填
+| ---------- | -------------------------------------- | ------- | ------------------------------------------------------------------- | -------- |-------- |
+| fontSize | 文字尺寸 (单位为px)  | number  | - | 14 | 可选 |
+| fontColor  | 文字颜色  | String | - | 文本: `#646A73`, 按钮: `#9CA2A9` | 可选 |
+
+## 事件
+
+| 事件名称 | 说明          | 返回参数  |
+|---------- |-------------- |---------- |
+| onWillExpand | 文本将要展开事件, 可在该事件中返回false来自定义展示处理 | text 文本  |
+| onExpand | 文本展开事件 | - |
+| onWillCollapse | 文本将要收起事件 | - |
+| onCollapse | 文本收起事件 | - |

--- a/docs/nav.config.yml
+++ b/docs/nav.config.yml
@@ -129,3 +129,5 @@ components:
         items:
           - title: 日历
             name: Calendar
+          - title: 省略器
+            name: Ellipsis

--- a/docs/page-route.js
+++ b/docs/page-route.js
@@ -46,5 +46,6 @@ export default {
   tabs: 'navigation/tabs',
   indexes: 'navigation/indexes',
   calendar: 'advanced/calendar',
+  ellipsis: 'advanced/ellipsis',
   form: 'form/form'
 }

--- a/docs/view/Ellipsis/index.jsx
+++ b/docs/view/Ellipsis/index.jsx
@@ -1,0 +1,12 @@
+import * as Nerv from 'nervjs'
+import EllipsisDoc from '@md/ellipsis.md'
+
+class EllipsisView extends Nerv.Component {
+  render () {
+    return (
+      <EllipsisDoc />
+    )
+  }
+}
+
+export default EllipsisView

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -58,6 +58,7 @@ class App extends Component {
       'pages/form/image-picker/index',
       'pages/form/range/index',
       'pages/advanced/calendar/index',
+      'pages/advanced/ellipsis/index',
       'pages/theme/index'
     ],
     window: {
@@ -68,15 +69,15 @@ class App extends Component {
     }
   }
 
-  componentDidMount () {}
+  componentDidMount() {}
 
-  componentDidShow () {}
+  componentDidShow() {}
 
-  componentDidHide () {}
+  componentDidHide() {}
 
-  componentCatchError () {}
+  componentCatchError() {}
 
-  render () {
+  render() {
     return <Index />
   }
 }

--- a/src/components/ellipsis/index.tsx
+++ b/src/components/ellipsis/index.tsx
@@ -1,0 +1,265 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+import classNames from 'classnames'
+import PropTypes, { InferProps } from 'prop-types'
+import { View, Canvas } from '@tarojs/components'
+import Taro from '@tarojs/taro'
+import { AtEllipsisProps, AtEllipsisState } from 'types/ellipsis'
+import AtComponent from '../../common/component'
+
+import { delayQuerySelector, isTest, uuid } from '../../common/utils'
+
+const ENV = Taro.getEnv()
+
+const DEFAULT_FONT_SIZE = 14
+const DEFAULT_TEXT_COLOR = '#646A73'
+const DEFAULT_BTN_COLOR = '#9CA2A9'
+
+const PLACEHOLDER = '...X'
+
+const isWEB = Taro.getEnv() === Taro.ENV_TYPE.WEB
+
+export default class AtEllipsis extends AtComponent<
+  AtEllipsisProps,
+  AtEllipsisState
+> {
+  public static defaultProps: AtEllipsisProps
+  public static propTypes: InferProps<AtEllipsisProps>
+  id: string
+  constructor(props: AtEllipsisProps) {
+    super(props)
+
+    this.id = isTest() ? 'indexes-ellipsis-AOTU2018' : `ellipsis-${uuid()}`
+    this.state = {
+      texts: [],
+      isMore: false,
+      isExpand: !!props.expand
+    }
+
+    this.onSwitch = this.onSwitch.bind(this)
+  }
+
+  public componentDidMount(): void {
+    if (this.props.text) {
+      this.initData()
+    }
+  }
+
+  private initData(): void {
+    if (isWEB) {
+      const elem = document.querySelector(`#${this.id}`)
+      if (!elem) return
+      const width = elem.getBoundingClientRect().width
+      this.createCanvas({ width })
+      return
+    }
+    delayQuerySelector(this, `#${this.id}`).then(rect => {
+      this.createCanvas(rect[0])
+    })
+  }
+
+  private createCanvas({ width }): void {
+    let context
+    let canvas
+    if (isWEB) {
+      canvas = document.createElement('canvas')
+      document.body.appendChild(canvas)
+      if (!canvas) return
+      context = canvas.getContext('2d')
+    } else {
+      context = Taro.createCanvasContext('canvas')
+    }
+
+    const {
+      text = '',
+      btnText = '',
+      lines,
+      textStyle = {},
+      btnTextStyle = {}
+    } = this.props
+    const fontSize = parseInt(`${textStyle.fontSize || DEFAULT_FONT_SIZE}`)
+    const btnTextSize = parseInt(
+      `${btnTextStyle.fontSize || DEFAULT_FONT_SIZE}`
+    )
+    isWEB
+      ? (context.font = `${btnTextSize}px Arial`)
+      : context.setFontSize(btnTextSize)
+    const placeholderWidth = context.measureText(PLACEHOLDER + btnText).width
+
+    const chr = text.split('')
+
+    isWEB
+      ? (context.font = `${fontSize}px Arial`)
+      : context.setFontSize(fontSize)
+    const row: Array<string> = []
+    let temp = ''
+    let isMore = false
+    for (let i = 0; i < chr.length; i++) {
+      if (row.length === lines) {
+        isMore = true
+        temp = ''
+        break
+      }
+      let totalWidth = width
+      const t = temp
+      if (row.length + 1 === lines) {
+        totalWidth -= placeholderWidth
+      }
+
+      if (
+        context.measureText(t + chr[i]).width <= totalWidth &&
+        chr[i] !== '\\n'
+      ) {
+        temp += chr[i]
+      } else {
+        row.push(temp)
+        temp = chr[i]
+      }
+    }
+    temp && row.push(temp)
+    isMore && (row[row.length - 1] = `${row[row.length - 1]}...`)
+
+    if (isWEB) {
+      document.body.removeChild(canvas)
+    }
+    this.setState({
+      texts: row,
+      isMore
+    })
+  }
+
+  private onSwitch(): void {
+    const {
+      onExpand = (): void => {},
+      onWillExpand = (): void => {},
+      onWillCollapse = (): void => {},
+      onCollapse = (): void => {}
+    } = this.props
+    const originExpand = this.state.isExpand
+    if (originExpand) {
+      const willExpand = onWillExpand(this.props.text)
+
+      if (typeof willExpand === 'boolean' && willExpand === false) return
+      this.setState(
+        {
+          isExpand: !originExpand
+        },
+        () => {
+          onExpand()
+        }
+      )
+    } else {
+      onWillCollapse()
+
+      this.setState(
+        {
+          isExpand: !originExpand
+        },
+        () => {
+          onCollapse()
+        }
+      )
+    }
+  }
+
+  public render(): JSX.Element {
+    const {
+      text,
+      lines,
+      btnText,
+      expandText,
+      textStyle = {},
+      btnTextStyle = {}
+    } = this.props
+    const { texts, isMore, isExpand } = this.state
+    const textSize = textStyle.fontSize || DEFAULT_FONT_SIZE
+
+    const textColor = textStyle.color || DEFAULT_TEXT_COLOR
+    const btnTextSize = btnTextStyle.fontSize || DEFAULT_FONT_SIZE
+    const btnTextColor = btnTextStyle.color || DEFAULT_BTN_COLOR
+
+    const tStyle = { fontSize: `${textSize}px`, color: textColor }
+    const bStyle = { fontSize: `${btnTextSize}px`, color: btnTextColor }
+
+    const rootClass = classNames({
+      'at-ellipsis': true,
+      [`at-ellipsis--${ENV}`]: true,
+      'at-ellipsis--lineclamp': lines
+    })
+
+    if (text) {
+      return (
+        <View>
+          <Canvas
+            canvasId='canvas'
+            style={{
+              position: 'fixed',
+              left: '-1000px',
+              top: '-1000px',
+              width: '100%',
+              height: '100%'
+            }}
+          />
+          <View id={this.id} className={rootClass} onClick={this.onSwitch}>
+            <View className='at-ellipsis__block' style={{ ...tStyle }}>
+              {text}
+            </View>
+            {isExpand &&
+              texts.map(t => (
+                <View className='at-ellipsis__text' key={t} style={tStyle}>
+                  {t}
+                </View>
+              ))}
+            {!isExpand && <View style={tStyle}>{text}</View>}
+            {isMore && (
+              <View className='at-ellipsis__btn' style={bStyle}>
+                {isExpand ? btnText : expandText}
+              </View>
+            )}
+          </View>
+        </View>
+      )
+    }
+
+    return (
+      <View
+        id={this.id}
+        className={rootClass}
+        style={{
+          // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+          // @ts-ignorets
+          '-webkit-line-clamp': `${lines}`,
+          ...textStyle
+        }}
+      >
+        {this.props.children}
+      </View>
+    )
+  }
+}
+
+AtEllipsis.defaultProps = {
+  text: '',
+  btnText: '全部',
+  expandText: '',
+  textStyle: {},
+  btnTextStyle: {},
+  expand: false,
+  onWillExpand: (): void => {},
+  onWillCollapse: (): void => {},
+  onExpand: (): void => {},
+  onCollapse: (): void => {}
+}
+
+AtEllipsis.propTypes = {
+  text: PropTypes.string,
+  btnText: PropTypes.string,
+  expandText: PropTypes.string,
+  textStyle: PropTypes.object,
+  lines: PropTypes.number,
+  expand: PropTypes.bool,
+  btnTextStyle: PropTypes.object,
+  onWillExpand: PropTypes.func,
+  onWillCollapse: PropTypes.func,
+  onExpand: PropTypes.func,
+  onCollapse: PropTypes.func
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,6 +56,7 @@ export { default as AtRange } from './components/range'
 export { default as AtIndexes } from './components/indexes'
 export { default as AtCalendar } from './components/calendar'
 export { default as AtFab } from './components/fab'
+export { default as AtEllipsis } from './components/ellipsis'
 
 /* 私有的组件  */
 export { default as AtLoading } from './components/loading'

--- a/src/pages/advanced/ellipsis/index.tsx
+++ b/src/pages/advanced/ellipsis/index.tsx
@@ -1,0 +1,88 @@
+import { View, Text } from '@tarojs/components'
+import Taro, { Component } from '@tarojs/taro'
+import { AtEllipsis } from 'taro-ui'
+import DocsHeader from '../../components/doc-header'
+
+export default class Index extends Component {
+  public constructor(props: any) {
+    super(props)
+    this.state = {}
+  }
+
+  public config: Taro.PageConfig = {
+    navigationBarTitleText: 'Taro UI CG'
+  }
+
+  public render(): JSX.Element {
+    return (
+      <View className='page'>
+        {/* S Header */}
+        <DocsHeader title='Ellipsis 省略器'></DocsHeader>
+        {/* E Header */}
+
+        {/* S Body */}
+        <View className='doc-body'>
+          {/* Radio */}
+          <View className='panel'>
+            <View className='panel__title'>Normal</View>
+            <View className='panel__content no-padding'>
+              <View className='radio-container'>
+                <AtEllipsis lines={2}>
+                  啊啊及发家史覅氨,,,
+                  <Text style='color: orange'>基酸覅健身房f奥</Text>
+                  术大师大所大所多奥术大师大所大按实际嗲圣诞节爱神的箭加斯安抚基酸覅健身房奥术大师大所大所多奥术大师大所大按实际嗲圣诞节爱神的箭加斯安抚
+                </AtEllipsis>
+              </View>
+            </View>
+          </View>
+
+          <View className='panel'>
+            <View className='panel__title'>展开/收起</View>
+            <View
+              className='panel__content no-padding'
+              style={{ width: '200px' }}
+            >
+              <AtEllipsis
+                text='啊啊及发家史覅氨,,,基酸覅健身房奥术大师大所大所多奥术大师大所大按实际嗲圣诞节爱神的箭加斯安抚基酸覅健身房奥术大师大所大所多奥术大师大所大按实际嗲圣诞节爱神的箭加斯安抚'
+                textStyle={{
+                  fontSize: 12
+                }}
+                btnText='全部展开全部'
+                expand
+                lines={2}
+              />
+            </View>
+          </View>
+
+          <View className='panel'>
+            <View className='panel__title'>自定义</View>
+            <View
+              className='panel__content no-padding'
+              style={{ width: '100px' }}
+            >
+              <AtEllipsis
+                text='啊啊及发家史覅氨,,,基酸覅健身房奥术大师大所大所多奥术大师大所大按实际嗲圣诞节爱神的箭加斯安抚基酸覅健身房奥术大师大所大所多奥术大师大所大按实际嗲圣诞节爱神的箭加斯安抚'
+                textStyle={{
+                  fontSize: 12
+                }}
+                btnText='查看全部'
+                btnTextStyle={{
+                  color: 'red'
+                }}
+                onWillExpand={(text: any): boolean => {
+                  Taro.showModal({
+                    title: text
+                  })
+                  return false
+                }}
+                expand
+                lines={2}
+              />
+            </View>
+          </View>
+        </View>
+        {/* E Body */}
+      </View>
+    )
+  }
+}

--- a/src/pages/panel/index.tsx
+++ b/src/pages/panel/index.tsx
@@ -1,16 +1,16 @@
-import { Image, Text, View } from '@tarojs/components';
-import { CommonEvent } from '@tarojs/components/types/common';
-import Taro, { Component } from '@tarojs/taro';
+import { Image, Text, View } from '@tarojs/components'
+import { CommonEvent } from '@tarojs/components/types/common'
+import Taro, { Component } from '@tarojs/taro'
 
-import iconAction from '../../assets/images/icon-list-action.png';
-import iconBasic from '../../assets/images/icon-list-basic.png';
-import iconForm from '../../assets/images/icon-list-form.png';
-import iconHOC from '../../assets/images/icon-list-hoc.png';
-import iconLayout from '../../assets/images/icon-list-layout.png';
-import iconNavigation from '../../assets/images/icon-list-navigation.png';
-import iconView from '../../assets/images/icon-list-view.png';
+import iconAction from '../../assets/images/icon-list-action.png'
+import iconBasic from '../../assets/images/icon-list-basic.png'
+import iconForm from '../../assets/images/icon-list-form.png'
+import iconHOC from '../../assets/images/icon-list-hoc.png'
+import iconLayout from '../../assets/images/icon-list-layout.png'
+import iconNavigation from '../../assets/images/icon-list-navigation.png'
+import iconView from '../../assets/images/icon-list-view.png'
 
-import './index.scss';
+import './index.scss'
 
 interface PanelBasicState {
   panelNames: {
@@ -33,7 +33,7 @@ export default class PanelBasic extends Component<{}, PanelBasicState> {
     navigationBarTitleText: 'Taro UI'
   }
 
-  public constructor () {
+  public constructor() {
     super(...arguments)
 
     this.state = {
@@ -284,6 +284,10 @@ export default class PanelBasic extends Component<{}, PanelBasicState> {
           {
             id: 'Calendar',
             name: '日历'
+          },
+          {
+            id: 'Ellipsis',
+            name: '省略器'
           }
         ]
       },
@@ -291,7 +295,7 @@ export default class PanelBasic extends Component<{}, PanelBasicState> {
     }
   }
 
-  public componentDidMount (): void {
+  public componentDidMount(): void {
     const { id } = this.$router.params
     this.setState({
       currentId: id.toLowerCase() || ''
@@ -305,7 +309,7 @@ export default class PanelBasic extends Component<{}, PanelBasicState> {
     })
   }
 
-  public render (): JSX.Element {
+  public render(): JSX.Element {
     const { list, currentId, panelNames } = this.state
     const itemList = list[currentId] || []
     const title = (panelNames[currentId] && panelNames[currentId].name) || ''

--- a/src/style/components/ellipsis.scss
+++ b/src/style/components/ellipsis.scss
@@ -1,0 +1,33 @@
+
+.at-ellipsis {
+  display: inline-block;
+  width: 100%;
+  overflow: hidden;
+  word-break: break-all;
+
+  /* autoprefixer: off */
+  -webkit-box-orient: vertical;
+  line-height: $line-height-zh;
+  font-size: $at-ellipsis-text-font-size;
+  color: $at-ellipsis-text-color;
+
+  &__block {
+    visibility: hidden;
+    height: 0;
+  }
+
+  &__btn {
+    position: absolute;
+    padding: 0 $spacing-h-sm;
+    right: 0;
+    bottom: 0;
+    background: rgba(255, 255, 255, 0.8);
+  }
+
+  &--lineclamp {
+    position: relative;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: -webkit-box;
+  }
+}

--- a/src/style/components/index.scss
+++ b/src/style/components/index.scss
@@ -50,3 +50,4 @@
 @import './textarea.scss';
 @import './timeline.scss';
 @import './toast.scss';
+@import './ellipsis.scss';

--- a/src/style/variables/default.scss
+++ b/src/style/variables/default.scss
@@ -455,3 +455,7 @@ $at-timeline-dot-size: 24px !default;
 $at-timeline-dot-color: $color-bg !default;
 $at-timeline-dot-border-color: $color-brand-light !default;
 $at-timeline-line-color: $color-border-lighter !default;
+
+/* Ellipsis */
+$at-ellipsis-text-color: #646A73;
+$at-ellipsis-text-font-size: $font-size-base;

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -53,6 +53,7 @@ export { default as AtRange } from './components/range'
 export { default as AtIndexes } from './components/indexes'
 export { default as AtCalendar } from './components/calendar'
 export { default as AtFab } from './components/fab'
+export { default as AtEllipsis } from './components/ellipsis'
 
 /* 私有的组件  */
 export { default as AtLoading } from './components/loading'

--- a/test/components/__snapshots__/ellipsis.test.js.snap
+++ b/test/components/__snapshots__/ellipsis.test.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AtDivider Snap render AtDivider -- props btnText 1`] = `"<div class=\\"\\"><div class=\\"taro-canvas\\" style=\\"position:fixed;left:-1000px;top:-1000px;width:100%;height:100%;\\"><canvas canvasId=\\"canvas\\" width=\\"300\\" height=\\"150\\"></canvas></div><div id=\\"indexes-ellipsis-AOTU2018\\" class=\\"at-ellipsis at-ellipsis--WEB at-ellipsis--lineclamp\\"><div style=\\"font-size:14px;color:#646A73;\\" class=\\"at-ellipsis__block\\">测试测试测试测试测试</div>undefinedundefined</div></div>"`;
+
+exports[`AtDivider Snap render AtDivider -- props expand 1`] = `"<div class=\\"\\"><div class=\\"taro-canvas\\" style=\\"position:fixed;left:-1000px;top:-1000px;width:100%;height:100%;\\"><canvas canvasId=\\"canvas\\" width=\\"300\\" height=\\"150\\"></canvas></div><div id=\\"indexes-ellipsis-AOTU2018\\" class=\\"at-ellipsis at-ellipsis--WEB at-ellipsis--lineclamp\\"><div style=\\"font-size:14px;color:#646A73;\\" class=\\"at-ellipsis__block\\">测试测试测试测试测试</div>undefinedundefined</div></div>"`;
+
+exports[`AtDivider Snap render AtEllipsis -- props lines 1`] = `"<div id=\\"indexes-ellipsis-AOTU2018\\" style=\\"-webkit-line-clamp:2;\\" class=\\"at-ellipsis at-ellipsis--WEB at-ellipsis--lineclamp\\">测试测试测试测试</div>"`;
+
+exports[`AtDivider Snap render AtEllipsis -- props text 1`] = `"<div class=\\"\\"><div class=\\"taro-canvas\\" style=\\"position:fixed;left:-1000px;top:-1000px;width:100%;height:100%;\\"><canvas canvasId=\\"canvas\\" width=\\"300\\" height=\\"150\\"></canvas></div><div id=\\"indexes-ellipsis-AOTU2018\\" class=\\"at-ellipsis at-ellipsis--WEB at-ellipsis--lineclamp\\"><div style=\\"font-size:14px;color:#646A73;\\" class=\\"at-ellipsis__block\\">测试测试测试测试测试</div>undefined<div style=\\"font-size:14px;color:#646A73;\\" class=\\"\\">测试测试测试测试测试</div>undefined</div></div>"`;

--- a/test/components/ellipsis.test.js
+++ b/test/components/ellipsis.test.js
@@ -1,0 +1,38 @@
+import Nerv from 'nervjs'
+import { renderToString } from 'nerv-server'
+import AtEllipsis from '../../.temp/components/ellipsis/index'
+
+describe('AtDivider Snap', () => {
+  it('render AtEllipsis -- props lines', () => {
+    const component = renderToString(
+      <AtEllipsis lines={2}>测试测试测试测试</AtEllipsis>
+    )
+    expect(component).toMatchSnapshot()
+  })
+
+  it('render AtEllipsis -- props text', () => {
+    const component = renderToString(
+      <AtEllipsis text='测试测试测试测试测试' lines={2} />
+    )
+    expect(component).toMatchSnapshot()
+  })
+
+  it('render AtDivider -- props expand', () => {
+    const component = renderToString(
+      <AtEllipsis text='测试测试测试测试测试' lines={2} expand />
+    )
+    expect(component).toMatchSnapshot()
+  })
+
+  it('render AtDivider -- props btnText', () => {
+    const component = renderToString(
+      <AtEllipsis
+        text='测试测试测试测试测试'
+        lines={2}
+        expand
+        btnText='查看全部'
+      />
+    )
+    expect(component).toMatchSnapshot()
+  })
+})

--- a/types/ellipsis.d.ts
+++ b/types/ellipsis.d.ts
@@ -1,0 +1,27 @@
+import { ComponentClass } from 'react'
+import AtComponent from './base'
+
+export interface AtEllipsisProps extends AtComponent {
+  text: string
+  btnText?: string
+  expand?: boolean
+  lines?: number
+  expandText?: string
+  textStyle?: { fontSize?: number | string; color?: string }
+  btnTextStyle?: { fontSize?: number | string; color?: string }
+
+  onWillExpand?: (text?: string) => boolean | void
+  onWillCollapse?: () => void
+  onExpand?: () => void
+  onCollapse?: () => void
+}
+
+export interface AtEllipsisState {
+  texts: Array<string>
+  isExpand: boolean
+  isMore: boolean
+}
+
+declare const AtEllipsis: ComponentClass<AtEllipsisProps>
+
+export default AtEllipsis

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -47,6 +47,7 @@ export { default as AtImagePicker } from './image-picker'
 export { default as AtIndexes } from './indexes'
 export { default as AtRange } from './range'
 export { default as AtFloatButton } from './float-button'
+export { default as AtEllipsis } from './ellipsis'
 
 export declare const AtCalendar: ComponentClass<Props>
 


### PR DESCRIPTION
### 添加Ellipsis省略器组件
**两种方式:**

- 提供 props of text, 将会使用canvas计算每行显示的文字个数, 并在右下角出现 全部 按钮, 点击可以切换 展开/收起
- 提供 props.children, 将只会单纯利用样式控制文字的超出隐藏
