### PR TITLE
fix(input): 不传入 name 时多个输入框表现异常

### DIFF
--- a/packages/taro-ui/src/components/input/index.tsx
+++ b/packages/taro-ui/src/components/input/index.tsx
@@ -147,6 +147,7 @@ export default class AtInput extends React.Component<AtInputProps> {
     })
     const placeholderCls = classNames('placeholder', placeholderClass)
 
+    const id = name && { id: name }
     return (
       <View className={rootCls} style={customStyle}>
         <View className={containerCls}>
@@ -163,7 +164,7 @@ export default class AtInput extends React.Component<AtInputProps> {
           )}
           <Input
             className='at-input__input'
-            id={name}
+            {...id}
             name={name}
             type={type}
             password={password}


### PR DESCRIPTION
修复： #1164 
如果不传入 `name` 在小程序端会表现异常，`H5` 端表现正常  