### PR TITLE
fix: h5 中页面加载时，报错_createSelectQuery is not defined

### DIFF
--- a/packages/taro-ui/package.json
+++ b/packages/taro-ui/package.json
@@ -2,7 +2,6 @@
   "name": "taro-ui",
   "version": "3.0.0-alpha.3",
   "description": "UI KIT for Taro",
-  "browser": "dist/index.umd.js",
   "module": "dist/index.esm.js",
   "main": "dist/index.js",
   "source": "src/index.ts",


### PR DESCRIPTION
Taro-ui 3.0.0-alpha.3下使用AtIndexes，在H5中页面加载时报：_createSelectQuery is not defined，而weapp内没有问题。