### PR TITLE
fix(modal.d.ts): isOpened 类型改为选填

### DIFF
--- a/packages/taro-ui/types/modal.d.ts
+++ b/packages/taro-ui/types/modal.d.ts
@@ -12,7 +12,7 @@ export interface AtModalProps extends AtComponent {
    * 是否显示模态框
    * @default false
    */
-  isOpened: boolean
+  isOpened?: boolean
   /**
    * 元素的内容
    */


### PR DESCRIPTION
看了一下`modal`的逻辑，`isOpened`改为选填是没有问题的。在日常开发中可能会这样定义`isOpened`的值：
```javascript
const [opened, setOpened] = useState<boolean>();

render () {
   return  <Modal isOpened={opened} />
}
```
或者这样定义
```javascript
const [action, setAction] = useState<{visible?: boolean; type: 'cancel'| 'confirm'}>({});

render () {
   return  <Modal isOpened={action.visible} />
}
```

如果将`isOpened`类型改为选填，那么在日常开发中可以不用硬编码一次`boolean`值