### PR TITLE
fix ios15输入框disabled 无效的问题

### DIFF
--- a/src/components/input/index.tsx
+++ b/src/components/input/index.tsx
@@ -174,6 +174,7 @@ export default class AtInput extends AtComponent<AtInputProps> {
             maxLength={maxLength}
             autoFocus={autoFocus}
             focus={focus}
+            disabled={disabled}
             value={value}
             confirmType={confirmType}
             cursor={cursor}

--- a/src/components/input/index.tsx
+++ b/src/components/input/index.tsx
@@ -232,7 +232,7 @@ AtInput.defaultProps = {
   error: false,
   clear: false,
   autoFocus: false,
-  focus: false,
+  focus: null,
   required: false,
   onChange: () => {},
   onFocus: () => {},


### PR DESCRIPTION
解决在ios 15 真机环境的微信小程序 输入框设置disabled 无效