### PR TITLE
chore(release): publish 3.1.0-beta.1

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -12,6 +12,6 @@
       "license": "MIT"
     }
   },
-  "version": "3.1.0-beta.0",
+  "version": "3.1.0-beta.1",
   "npmClient": "yarn"
 }

--- a/packages/taro-ui-demo-rn/package.json
+++ b/packages/taro-ui-demo-rn/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "taro-ui-demo-rn",
-  "version": "3.1.0-beta.0",
+  "version": "3.1.0-beta.1",
   "description": "Taro UI demo",
   "author": "O2Team <aotu.io>",
   "homepage": "https://taro-ui.aotu.io",
@@ -52,7 +52,7 @@
     "react-dom": "^16.13.0",
     "react-native": "^0.66.0",
     "react-native-modal": "^13.0.0",
-    "taro-ui": "^3.1.0-beta.0"
+    "taro-ui": "^3.1.0-beta.1"
   },
   "devDependencies": {
     "@babel/core": "^7.8.0",

--- a/packages/taro-ui-demo-rn/src/app.config.ts
+++ b/packages/taro-ui-demo-rn/src/app.config.ts
@@ -46,7 +46,7 @@ const pages = [
   'pages/form/switch/index',
   'pages/form/rate/index',
   'pages/form/picker/index',
-  // 'pages/form/picker-view/index',
+  'pages/form/picker-view/index',
   'pages/form/slider/index',
   'pages/form/search-bar/index',
   'pages/form/image-picker/index',

--- a/packages/taro-ui-demo-rn/src/pages/basic/button/index.tsx
+++ b/packages/taro-ui-demo-rn/src/pages/basic/button/index.tsx
@@ -36,7 +36,7 @@ export default class ButtonPage extends React.Component<{}, ButtonPageState> {
     return {
       title: 'Taro UI',
       path: '/pages/index/index',
-      imageUrl: 'http://storage.360buyimg.com/mtd/home/share1535013100318.jpg'
+      imageUrl: 'https://storage.360buyimg.com/mtd/home/share1535013100318.jpg'
     }
   }
 

--- a/packages/taro-ui-demo-rn/src/pages/form/picker-view/index.scss
+++ b/packages/taro-ui-demo-rn/src/pages/form/picker-view/index.scss
@@ -1,7 +1,8 @@
-.example-item {
-  .title-date {
-    margin: 40px 0 20px;
-    text-align: center;
-    font-size: 36px;
-  }
+.title-date {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: row;
+  font-size: 32px;
+  margin-top: 100px;
 }

--- a/packages/taro-ui-demo-rn/src/pages/form/picker-view/index.tsx
+++ b/packages/taro-ui-demo-rn/src/pages/form/picker-view/index.tsx
@@ -13,8 +13,8 @@ interface IndexState {
   days: number[]
   day: number
   value: number[]
-  isWeapp: boolean
-  isAlipay: boolean
+  isWeapp?: boolean
+  isAlipay?: boolean
 }
 
 export default class Index extends React.Component<{}, IndexState> {
@@ -46,18 +46,16 @@ export default class Index extends React.Component<{}, IndexState> {
       month: 2,
       days,
       day: 2,
-      value: [9999, 5, 17],
-      isWeapp: false,
-      isAlipay: false
+      value: [9999, 5, 17]
     }
   }
 
   public componentDidMount(): void {
-    const env = Taro.getEnv()
-    this.setState({
-      isWeapp: env === Taro.ENV_TYPE.WEAPP,
-      isAlipay: env === Taro.ENV_TYPE.ALIPAY
-    })
+    // const env = Taro.getEnv()
+    // this.setState({
+    //   isWeapp: env === Taro.ENV_TYPE.WEAPP,
+    //   isAlipay: env === Taro.ENV_TYPE.ALIPAY
+    // })
   }
 
   private handleChange = (e: CommonEvent): void => {
@@ -72,17 +70,7 @@ export default class Index extends React.Component<{}, IndexState> {
   }
 
   public render(): JSX.Element {
-    const {
-      years,
-      months,
-      days,
-      value,
-      year,
-      month,
-      day,
-      isWeapp,
-      isAlipay
-    } = this.state
+    const { years, months, days, value, year, month, day } = this.state
 
     return (
       <View className='page'>
@@ -98,47 +86,29 @@ export default class Index extends React.Component<{}, IndexState> {
             <View className='panel__content'>
               <View className='panel__content--example-item'>
                 <View className='example-item__desc'>嵌入页面的滑动选择器</View>
-                {isWeapp || isAlipay ? (
-                  <View>
-                    <View className='title-date'>
-                      {year}年{month}月{day}日
-                    </View>
-                    <PickerView
-                      indicatorStyle='height: 50px;'
-                      className='picker'
-                      style='width: 100%; height: 300px; text-align: center;'
-                      value={value}
-                      onChange={this.handleChange}
-                    >
-                      <PickerViewColumn>
-                        {years.map((item, idx) => (
-                          <View key={idx} style='line-height: 50px'>
-                            {item}年
-                          </View>
-                        ))}
-                      </PickerViewColumn>
-                      <PickerViewColumn>
-                        {months.map((item, idx) => (
-                          <View key={idx} style='line-height: 50px'>
-                            {item}月
-                          </View>
-                        ))}
-                      </PickerViewColumn>
-                      <PickerViewColumn>
-                        {days.map((item, idx) => (
-                          <View key={idx} style='line-height: 50px'>
-                            {item}日
-                          </View>
-                        ))}
-                      </PickerViewColumn>
-                    </PickerView>
-                  </View>
-                ) : (
-                  <View className='title-date'>暂时仅支持微信小程序</View>
-                )}
+                <View className='title-date'>
+                  {year}年{month}月{day}日
+                </View>
               </View>
             </View>
           </View>
+          <PickerView value={value} onChange={this.handleChange}>
+            <PickerViewColumn>
+              {years.map(item => {
+                return <View key={item}>{item}年</View>
+              })}
+            </PickerViewColumn>
+            <PickerViewColumn>
+              {months.map(item => {
+                return <View key={item}>{item}月</View>
+              })}
+            </PickerViewColumn>
+            <PickerViewColumn>
+              {days.map(item => {
+                return <View key={item}>{item}日</View>
+              })}
+            </PickerViewColumn>
+          </PickerView>
         </View>
         {/* E Body */}
       </View>

--- a/packages/taro-ui-demo-rn/src/pages/index/index.tsx
+++ b/packages/taro-ui-demo-rn/src/pages/index/index.tsx
@@ -81,7 +81,7 @@ export default class Index extends React.Component<{}, IndexState> {
     return {
       title: 'Taro UI',
       path: '/pages/index/index',
-      imageUrl: 'http://storage.360buyimg.com/mtd/home/share1535013100318.jpg'
+      imageUrl: 'https://storage.360buyimg.com/mtd/home/share1535013100318.jpg'
     }
   }
 

--- a/packages/taro-ui-demo-rn/src/pages/navigation/indexes/index.tsx
+++ b/packages/taro-ui-demo-rn/src/pages/navigation/indexes/index.tsx
@@ -58,7 +58,7 @@ export default class Index extends React.Component<{}, IndexesState> {
 
   public render(): JSX.Element {
     return (
-      <View className='page' style='height: 100vh;'>
+      <View className='page'>
         {/* 基础用法 */}
         <View style='height: 100%;'>
           <AtIndexes

--- a/packages/taro-ui-demo-rn/src/pages/navigation/tabbar/index.tsx
+++ b/packages/taro-ui-demo-rn/src/pages/navigation/tabbar/index.tsx
@@ -11,7 +11,7 @@ interface IndexPageState {
 
 export default class Index extends React.Component<{}, IndexPageState> {
   public config: Taro.PageConfig = {
-    navigationBarTitleText: 'Taro UI',
+    navigationBarTitleText: 'Taro UI'
   }
 
   public constructor(props: any) {
@@ -21,13 +21,13 @@ export default class Index extends React.Component<{}, IndexPageState> {
       current2: 0,
       current3: 0,
       current4: 0,
-      current5: 0,
+      current5: 0
     }
   }
 
   private handleClick(num: number, value: number): void {
     this.setState({
-      [`current${num}`]: value,
+      [`current${num}`]: value
     })
   }
 
@@ -36,12 +36,12 @@ export default class Index extends React.Component<{}, IndexPageState> {
     const tabList1 = [
       { title: '待办事项', text: 8 },
       { title: '拍照' },
-      { title: '通讯录', dot: true },
+      { title: '通讯录', dot: true }
     ]
     const tabList2 = [
       { title: '待办事项', iconType: 'bullet-list', text: 'new' },
       { title: '拍照', iconType: 'camera' },
-      { title: '文件夹', iconType: 'folder', text: '100', max: 99 },
+      { title: '文件夹', iconType: 'folder', text: '100', max: 99 }
     ]
     const tabList3 = [
       {
@@ -50,20 +50,20 @@ export default class Index extends React.Component<{}, IndexPageState> {
           'https://img12.360buyimg.com/jdphoto/s72x72_jfs/t6160/14/2008729947/2754/7d512a86/595c3aeeNa89ddf71.png',
         selectedImage:
           'https://img14.360buyimg.com/jdphoto/s72x72_jfs/t17251/336/1311038817/3177/72595a07/5ac44618Na1db7b09.png',
-        text: 'new',
+        text: 'new'
       },
       {
         title: '找折扣',
         image:
-          'https://img20.360buyimg.com/jdphoto/s72x72_jfs/t15151/308/1012305375/2300/536ee6ef/5a411466N040a074b.png',
+          'https://img20.360buyimg.com/jdphoto/s72x72_jfs/t15151/308/1012305375/2300/536ee6ef/5a411466N040a074b.png'
       },
       {
         title: '领会员',
         image:
           'https://img10.360buyimg.com/jdphoto/s72x72_jfs/t5872/209/5240187906/2872/8fa98cd/595c3b2aN4155b931.png',
         text: '100',
-        max: 99,
-      },
+        max: 99
+      }
     ]
 
     return (

--- a/packages/taro-ui-demo-rn/src/pages/view/article/index.tsx
+++ b/packages/taro-ui-demo-rn/src/pages/view/article/index.tsx
@@ -39,7 +39,7 @@ export default class ArticlePage extends React.Component {
                     </View>
                     <Image
                       className='at-article__img'
-                      src='http://storage.360buyimg.com/mtd/home/32443566_635798770100444_2113947400891531264_n1533825816008.jpg'
+                      src='https://storage.360buyimg.com/mtd/home/32443566_635798770100444_2113947400891531264_n1533825816008.jpg'
                       mode='widthFix'
                     />
                   </View>

--- a/packages/taro-ui-demo/package.json
+++ b/packages/taro-ui-demo/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "taro-ui-demo",
-  "version": "3.1.0-beta.0",
+  "version": "3.1.0-beta.1",
   "description": "Taro UI demo",
   "author": "O2Team <aotu.io>",
   "homepage": "https://taro-ui.aotu.io",

--- a/packages/taro-ui-demo/src/pages/action/toast/index.tsx
+++ b/packages/taro-ui-demo/src/pages/action/toast/index.tsx
@@ -51,15 +51,8 @@ export default class ToastPage extends React.Component<{}, ToastPageState> {
   }
 
   public render(): JSX.Element {
-    const {
-      text,
-      icon,
-      status,
-      isOpened,
-      duration,
-      image,
-      hasMask
-    } = this.state
+    const { text, icon, status, isOpened, duration, image, hasMask } =
+      this.state
 
     return (
       <View className='page toast-page'>
@@ -102,7 +95,7 @@ export default class ToastPage extends React.Component<{}, ToastPageState> {
                   onClick={this.handleClick.bind(this, {
                     text: '凹凸实验室',
                     image:
-                      'http://storage.360buyimg.com/mtd/home/group-21533885306540.png'
+                      'https://storage.360buyimg.com/mtd/home/group-21533885306540.png'
                   })}
                 >
                   自定义图片 Toast

--- a/packages/taro-ui/package.json
+++ b/packages/taro-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "taro-ui",
-  "version": "3.1.0-beta.0",
+  "version": "3.1.0-beta.1",
   "description": "UI KIT for Taro",
   "module": "dist/index.esm.js",
   "main": "dist/index.js",

--- a/packages/taro-ui/rn/components/button/index.tsx
+++ b/packages/taro-ui/rn/components/button/index.tsx
@@ -9,12 +9,12 @@ import { AtButtonProps, AtButtonState } from '../../../types/button'
 
 const SIZE_CLASS = {
   normal: 'normal',
-  small: 'small',
+  small: 'small'
 }
 
 const TYPE_CLASS = {
   primary: 'primary',
-  secondary: 'secondary',
+  secondary: 'secondary'
 }
 
 export default class AtButton extends React.Component<
@@ -29,7 +29,7 @@ export default class AtButton extends React.Component<
     this.state = {
       isWEB: Taro.getEnv() === Taro.ENV_TYPE.WEB,
       isWEAPP: Taro.getEnv() === Taro.ENV_TYPE.WEAPP,
-      isALIPAY: Taro.getEnv() === Taro.ENV_TYPE.ALIPAY,
+      isALIPAY: Taro.getEnv() === Taro.ENV_TYPE.ALIPAY
     }
   }
 
@@ -45,7 +45,7 @@ export default class AtButton extends React.Component<
       full,
       loading,
       disabled,
-      customStyle,
+      customStyle
     } = this.props
     const rootClassName = ['at-button']
     const classObject = {
@@ -53,8 +53,9 @@ export default class AtButton extends React.Component<
       [`at-button--${type}`]: TYPE_CLASS[type],
       [`at-button--${SIZE_CLASS[size]}`]: SIZE_CLASS[size],
       'at-button--circle': circle,
-      'at-button--full': full,
+      'at-button--full': full
     }
+
     return (
       <Button
         disabled={disabled}
@@ -62,7 +63,7 @@ export default class AtButton extends React.Component<
         style={customStyle}
         // @ts-ignore
         hoverStyle={{
-          opacity: 0.6,
+          opacity: 0.6
         }}
         loading={loading}
         type={type !== 'primary' ? 'default' : 'primary'}
@@ -97,7 +98,7 @@ AtButton.defaultProps = {
   sendMessagePath: '',
   sendMessageImg: '',
   showMessageCard: false,
-  appParameter: '',
+  appParameter: ''
 }
 
 AtButton.propTypes = {
@@ -121,7 +122,7 @@ AtButton.propTypes = {
     'getRealnameAuthInfo',
     'getAuthorize',
     'contactShare',
-    '',
+    ''
   ]),
   lang: PropTypes.string,
   sessionFrom: PropTypes.string,
@@ -134,5 +135,5 @@ AtButton.propTypes = {
   onContact: PropTypes.func,
   onGetPhoneNumber: PropTypes.func,
   onError: PropTypes.func,
-  onOpenSetting: PropTypes.func,
+  onOpenSetting: PropTypes.func
 }

--- a/packages/taro-ui/rn/components/checkbox/index.tsx
+++ b/packages/taro-ui/rn/components/checkbox/index.tsx
@@ -35,7 +35,7 @@ export default class AtCheckbox extends React.Component<AtCheckboxProps<any>> {
           const { value, disabled, label, desc } = option
           const optionCls = classNames('at-checkbox__option', {
             'at-checkbox__option--disabled': disabled,
-            'at-checkbox__option--selected': selectedList.includes(value),
+            'at-checkbox__option--selected': selectedList.includes(value)
           })
 
           return (
@@ -48,26 +48,26 @@ export default class AtCheckbox extends React.Component<AtCheckboxProps<any>> {
                 className={classNames({
                   'at-checkbox__option-wrap': true,
                   'at-checkbox__option-wrap--without-border':
-                    !border || idx === 0,
+                    !border || idx === 0
                 })}
               >
                 <View
                   className={classNames({
                     'at-checkbox__option-cnt': true,
-                    'at-checkbox__option-cnt--disabled': disabled,
+                    'at-checkbox__option-cnt--disabled': disabled
                   })}
                 >
                   <View
                     className={classNames({
                       'at-checkbox__icon-cnt': true,
                       'at-checkbox__icon-cnt--check':
-                        selectedList.includes(value),
+                        selectedList.includes(value)
                     })}
                   >
                     <AtIcon
                       className={classNames({
                         'at-checkbox__icon-cnt--check':
-                          selectedList.includes(value),
+                          selectedList.includes(value)
                       })}
                       value='check'
                       color='#FFF'
@@ -79,7 +79,7 @@ export default class AtCheckbox extends React.Component<AtCheckboxProps<any>> {
                   <View
                     className={classNames({
                       'at-checkbox__desc': true,
-                      'at-checkbox__desc--disabled': disabled,
+                      'at-checkbox__desc--disabled': disabled
                     })}
                   >
                     {desc}
@@ -101,7 +101,7 @@ AtCheckbox.defaultProps = {
   options: [],
   selectedList: [],
   // eslint-disable-next-line @typescript-eslint/no-empty-function
-  onChange: (): void => {},
+  onChange: (): void => {}
 }
 
 AtCheckbox.propTypes = {
@@ -109,5 +109,5 @@ AtCheckbox.propTypes = {
   className: PropTypes.oneOfType([PropTypes.array, PropTypes.string]),
   options: PropTypes.array,
   selectedList: PropTypes.array,
-  onChange: PropTypes.func,
+  onChange: PropTypes.func
 }

--- a/packages/taro-ui/rn/components/input/index.tsx
+++ b/packages/taro-ui/rn/components/input/index.tsx
@@ -10,7 +10,7 @@ import {
   ConfirmEventDetail,
   FocusEventDetail,
   InputEventDetail,
-  KeyboardHeightEventDetail,
+  KeyboardHeightEventDetail
 } from '../../../types/input'
 import '../../style/components/input.scss'
 import AtIcon from '../icon'
@@ -26,7 +26,7 @@ function getInputProps(props: AtInputProps): GetInputPropsReturn {
     type: props.type,
     maxlength: props.maxlength,
     disabled: props.disabled,
-    password: false,
+    password: false
   }
 
   switch (actualProps.type) {
@@ -70,7 +70,7 @@ export default class AtInput extends React.Component<AtInputProps> {
       // fix # 583 AtInput 不触发 onChange 的问题
       this.props.onChange(
         event.detail.value,
-        event as BaseEventOrig<InputEventDetail>,
+        event as BaseEventOrig<InputEventDetail>
       )
     }
     // 还原状态
@@ -95,7 +95,7 @@ export default class AtInput extends React.Component<AtInputProps> {
   }
 
   private handleKeyboardHeightChange = (
-    event: BaseEventOrig<KeyboardHeightEventDetail>,
+    event: BaseEventOrig<KeyboardHeightEventDetail>
   ): void => {
     if (typeof this.props.onKeyboardHeightChange === 'function') {
       this.props.onKeyboardHeightChange(event)
@@ -129,12 +129,12 @@ export default class AtInput extends React.Component<AtInputProps> {
       autoFocus,
       focus,
       value,
-      required,
+      required
     } = this.props
     const { type, maxlength, disabled, password } = getInputProps(this.props)
 
     const overlayCls = classNames('at-input__overlay', {
-      'at-input__overlay--hidden': !disabled,
+      'at-input__overlay--hidden': !disabled
     })
     const placeholderCls = classNames('placeholder', placeholderClass)
 
@@ -144,16 +144,16 @@ export default class AtInput extends React.Component<AtInputProps> {
         className={classNames(
           'at-input',
           {
-            'at-input--without-border': !border,
+            'at-input--without-border': !border
           },
-          className,
+          className
         )}
         style={customStyle}
       >
         <View
           className={classNames('at-input__container', {
             'at-input--error': error,
-            'at-input--disabled': disabled,
+            'at-input--disabled': disabled
           })}
         >
           <View className={overlayCls} onClick={this.handleClick} />
@@ -163,7 +163,7 @@ export default class AtInput extends React.Component<AtInputProps> {
               <Label
                 className={classNames('at-input__title', {
                   'at-input__title--error': error,
-                  'at-input__title--disabled': disabled,
+                  'at-input__title--disabled': disabled
                 })}
                 for={name}
               >
@@ -243,7 +243,7 @@ AtInput.defaultProps = {
   focus: false,
   required: false,
   // eslint-disable-next-line @typescript-eslint/no-empty-function
-  onChange: (): void => {},
+  onChange: (): void => {}
 }
 
 AtInput.propTypes = {
@@ -276,5 +276,5 @@ AtInput.propTypes = {
   onConfirm: PropTypes.func,
   onErrorClick: PropTypes.func,
   onClick: PropTypes.func,
-  required: PropTypes.bool,
+  required: PropTypes.bool
 }

--- a/packages/taro-ui/rn/components/noticebar/index.tsx
+++ b/packages/taro-ui/rn/components/noticebar/index.tsx
@@ -21,13 +21,13 @@ export default class AtNoticebar extends React.Component<
     super(props)
     this.state = {
       show: true,
-      transformX: new Animated.Value(0),
+      transformX: new Animated.Value(0)
     }
   }
 
   private onClose(event: CommonEvent): void {
     this.setState({
-      show: false,
+      show: false
     })
     this.props.onClose && this.props.onClose(event)
   }
@@ -62,8 +62,9 @@ export default class AtNoticebar extends React.Component<
         {!!icon && (
           <AtIcon
             customStyle={{
+              // ios 生效，android 不生效，考虑换成图
               marginRight: -3,
-              marginBottom: -3,
+              marginBottom: -3
             }}
             className='at-noticebar__content-icon__at-icon'
             value={icon}
@@ -87,7 +88,7 @@ export default class AtNoticebar extends React.Component<
         toValue: -textWidth,
         duration: (textWidth * 30) / (speed / 100),
         easing: Easing.linear,
-        useNativeDriver: true,
+        useNativeDriver: true
       }).start(({ finished }) => {
         if (finished) {
           this.move()
@@ -101,7 +102,7 @@ export default class AtNoticebar extends React.Component<
     (event: any): void => {
       const { width } = event.nativeEvent.layout
       this.setState({
-        [key]: width,
+        [key]: width
       })
     }
 
@@ -111,7 +112,7 @@ export default class AtNoticebar extends React.Component<
       marquee,
       customStyle,
       className,
-      moreText = '查看详情',
+      moreText = '查看详情'
     } = this.props
     let { showMore, close } = this.props
     const { show } = this.state
@@ -152,7 +153,7 @@ export default class AtNoticebar extends React.Component<
               style={{
                 flex: 1,
                 paddingLeft: 10,
-                paddingRight: 10,
+                paddingRight: 10
               }}
             >
               <View style={style}>
@@ -195,7 +196,7 @@ AtNoticebar.defaultProps = {
   moreText: '查看详情',
   showMore: false,
   icon: '',
-  customStyle: {},
+  customStyle: {}
 }
 
 AtNoticebar.propTypes = {
@@ -208,5 +209,5 @@ AtNoticebar.propTypes = {
   icon: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   customStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
   onClose: PropTypes.func,
-  onGotoMore: PropTypes.func,
+  onGotoMore: PropTypes.func
 }

--- a/packages/taro-ui/rn/components/range/index.tsx
+++ b/packages/taro-ui/rn/components/range/index.tsx
@@ -3,7 +3,7 @@ import PropTypes, { InferProps } from 'prop-types'
 import React from 'react'
 import Taro from '@tarojs/taro'
 import { View } from '@tarojs/components'
-import { CommonEvent, ITouchEvent } from '@tarojs/components/types/common'
+import { CommonEvent } from '@tarojs/components/types/common'
 import { AtRangeProps, AtRangeState } from '../../../types/range'
 import '../../style/components/range.scss'
 
@@ -30,7 +30,7 @@ export default class AtRange extends React.Component<
     this.currentSlider = ''
     this.state = {
       aX: 0,
-      bX: 0,
+      bX: 0
     }
   }
 
@@ -45,7 +45,7 @@ export default class AtRange extends React.Component<
     }
   }
 
-  private handleTouchMove(sliderName: string, event: ITouchEvent): void {
+  private handleTouchMove(sliderName: string, event: any): void {
     if (this.props.disabled) return
 
     const clientX = event.nativeEvent.pageX
@@ -62,20 +62,20 @@ export default class AtRange extends React.Component<
   private setSliderValue(
     sliderName: string,
     targetValue: number,
-    funcName: string,
+    funcName: string
   ): void {
     const distance = Math.min(Math.max(targetValue, 0), this.width)
     const sliderValue = Math.floor((distance / this.width) * 100)
     if (funcName) {
       this.setState(
         {
-          [sliderName]: sliderValue,
+          [sliderName]: sliderValue
         },
-        () => this.triggerEvent(funcName),
+        () => this.triggerEvent(funcName)
       )
     } else {
       this.setState({
-        [sliderName]: sliderValue,
+        [sliderName]: sliderValue
       })
     }
   }
@@ -139,15 +139,15 @@ export default class AtRange extends React.Component<
       railStyle,
       trackStyle,
       blockSize,
-      disabled,
+      disabled
     } = this.props
 
     const rootCls = classNames(
       'at-range',
       {
-        'at-range--disabled': disabled,
+        'at-range--disabled': disabled
       },
-      className,
+      className
     )
 
     const { aX, bX } = this.state
@@ -165,11 +165,11 @@ export default class AtRange extends React.Component<
 
     const sliderAStyle = {
       ...sliderCommonStyle,
-      left: `${aX}%`,
+      left: `${aX}%`
     }
     const sliderBStyle = {
       ...sliderCommonStyle,
-      left: `${bX}%`,
+      left: `${bX}%`
     }
     const containerStyle: React.CSSProperties = {}
     if (blockSize) {
@@ -182,16 +182,17 @@ export default class AtRange extends React.Component<
     const deltaX = Math.abs(aX - bX)
     const atTrackStyle = {
       left: `${smallerX}%`,
-      width: `${deltaX}%`,
+      width: `${deltaX}%`
     }
 
     const shadowStyle = {
       shadowOffset: {
         width: 0,
-        height: 0,
+        height: 0
       },
       shadowOpacity: 0.2,
       shadowRadius: 2,
+      elevation: 2
     }
 
     return (
@@ -234,7 +235,7 @@ AtRange.defaultProps = {
   min: 0,
   max: 100,
   disabled: false,
-  blockSize: 0,
+  blockSize: 0
 }
 
 AtRange.propTypes = {
@@ -249,5 +250,5 @@ AtRange.propTypes = {
   disabled: PropTypes.bool,
   blockSize: PropTypes.number,
   onChange: PropTypes.func,
-  onAfterChange: PropTypes.func,
+  onAfterChange: PropTypes.func
 }

--- a/packages/taro-ui/rn/components/tab-bar/index.tsx
+++ b/packages/taro-ui/rn/components/tab-bar/index.tsx
@@ -44,20 +44,23 @@ export default class AtTabBar extends React.Component<AtTabBarProps> {
       color,
       iconSize,
       fontSize,
-      selectedColor,
+      selectedColor
     } = this.props
     // const { isIPhoneX } = this.state
     const defaultStyle = {
-      color: color || '',
+      color: color || ''
     }
     const selectedStyle = {
-      color: selectedColor || '',
+      color: selectedColor || ''
     }
-    const titleStyle = {
-      fontSize: +(fontSize ? `${fontSize}` : ''),
+    const titleStyle: React.CSSProperties = {}
+
+    if (fontSize) {
+      titleStyle.fontSize = +fontSize
     }
+
     const rootStyle = {
-      backgroundColor: backgroundColor || '',
+      backgroundColor: backgroundColor || ''
     }
     const imgStyle: any = {
       // width: iconSize,
@@ -73,17 +76,17 @@ export default class AtTabBar extends React.Component<AtTabBarProps> {
         className={classNames(
           {
             'at-tab-bar': true,
-            'at-tab-bar--fixed': fixed,
+            'at-tab-bar--fixed': fixed
             // 'at-tab-bar--ipx': isIPhoneX
           },
-          className,
+          className
         )}
         style={Object.assign(rootStyle, customStyle)}
       >
         {tabList.map((item: TabItem, i: number) => (
           <View
             className={classNames('at-tab-bar__item', {
-              'at-tab-bar__item--active': current === i,
+              'at-tab-bar__item--active': current === i
             })}
             style={current === i ? selectedStyle : defaultStyle}
             key={item.title}
@@ -134,7 +137,7 @@ export default class AtTabBar extends React.Component<AtTabBarProps> {
                   <View className='at-tab-bar__icon'>
                     <Image
                       className={classNames('at-tab-bar__inner-img', {
-                        'at-tab-bar__inner-img--inactive': current !== i,
+                        'at-tab-bar__inner-img--inactive': current !== i
                       })}
                       mode='widthFix'
                       src={item.selectedImage || item.image}
@@ -142,7 +145,7 @@ export default class AtTabBar extends React.Component<AtTabBarProps> {
                     ></Image>
                     <Image
                       className={classNames('at-tab-bar__inner-img', {
-                        'at-tab-bar__inner-img--inactive': current === i,
+                        'at-tab-bar__inner-img--inactive': current === i
                       })}
                       mode='widthFix'
                       src={item.image}
@@ -162,7 +165,7 @@ export default class AtTabBar extends React.Component<AtTabBarProps> {
                   className='at-tab-bar__title'
                   style={{
                     ...titleStyle,
-                    color: current === i ? selectedColor : color,
+                    color: current === i ? selectedColor : color
                   }}
                 >
                   {item.title}
@@ -185,7 +188,7 @@ AtTabBar.defaultProps = {
   current: 0,
   tabList: [],
   // eslint-disable-next-line @typescript-eslint/no-empty-function
-  onClick: (): void => {},
+  onClick: (): void => {}
 }
 
 AtTabBar.propTypes = {
@@ -199,5 +202,5 @@ AtTabBar.propTypes = {
   color: PropTypes.string,
   selectedColor: PropTypes.string,
   tabList: PropTypes.array,
-  onClick: PropTypes.func,
+  onClick: PropTypes.func
 }

--- a/packages/taro-ui/rn/components/textarea/index.tsx
+++ b/packages/taro-ui/rn/components/textarea/index.tsx
@@ -14,7 +14,7 @@ type ExtendEvent = {
 
 function getMaxLength(
   maxLength: number,
-  textOverflowForbidden: boolean,
+  textOverflowForbidden: boolean
 ): number {
   if (!textOverflowForbidden) {
     return maxLength + 500
@@ -67,7 +67,7 @@ export default class AtTextarea extends React.Component<AtTextareaProps> {
       selectionEnd,
       fixed,
       textOverflowForbidden = true,
-      height,
+      height
     } = this.props
 
     const _maxLength = parseInt(maxLength.toString())
@@ -108,7 +108,7 @@ export default class AtTextarea extends React.Component<AtTextareaProps> {
         {count && (
           <View
             className={classNames('at-textarea__counter', {
-              'at-textarea__counter--error': sizeError,
+              'at-textarea__counter--error': sizeError
             })}
           >
             {`${value.length}/${_maxLength}`}
@@ -137,7 +137,7 @@ AtTextarea.defaultProps = {
   height: '',
   textOverflowForbidden: true,
   // eslint-disable-next-line @typescript-eslint/no-empty-function
-  onChange: (): void => {},
+  onChange: (): void => {}
 }
 
 AtTextarea.propTypes = {
@@ -163,5 +163,5 @@ AtTextarea.propTypes = {
   onChange: PropTypes.func.isRequired,
   onFocus: PropTypes.func,
   onBlur: PropTypes.func,
-  onConfirm: PropTypes.func,
+  onConfirm: PropTypes.func
 }

--- a/packages/taro-ui/rn/components/timeline/index.tsx
+++ b/packages/taro-ui/rn/components/timeline/index.tsx
@@ -17,7 +17,7 @@ export default class AtTimeline extends React.Component<AtTimelineProps> {
     if (pending) rootClassName.push('at-timeline--pending')
 
     const rootClassObject = {
-      'at-timeline--pending': pending,
+      'at-timeline--pending': pending
     }
 
     const itemElems = items.map((item, index) => {
@@ -25,7 +25,7 @@ export default class AtTimeline extends React.Component<AtTimelineProps> {
 
       const iconClass = classNames({
         'at-icon': true,
-        'at-timeline-item__at-icon': true,
+        'at-timeline-item__at-icon': true
         // [`at-icon-${icon}`]: icon
       })
 
@@ -81,7 +81,7 @@ export default class AtTimeline extends React.Component<AtTimelineProps> {
         className={classNames(
           rootClassName,
           rootClassObject,
-          this.props.className,
+          this.props.className
         )}
         style={customStyle}
       >
@@ -94,11 +94,11 @@ export default class AtTimeline extends React.Component<AtTimelineProps> {
 AtTimeline.defaultProps = {
   pending: false,
   items: [],
-  customStyle: {},
+  customStyle: {}
 }
 
 AtTimeline.propTypes = {
   pending: PropTypes.bool,
   items: PropTypes.arrayOf(PropTypes.object),
-  customStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
+  customStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.string])
 }

--- a/packages/taro-ui/rn/style/components/checkbox.scss
+++ b/packages/taro-ui/rn/style/components/checkbox.scss
@@ -35,7 +35,7 @@ $component: '.at-checkbox';
     //  display: inline-flex;
     align-items: center;
     justify-content: center;
-    // margin-top: 4px;
+    margin-top: 4px;
     margin-right: $spacing-h-lg;
     width: $at-checkbox-circle-size;
     min-width: $at-checkbox-circle-size;

--- a/packages/taro-ui/rn/style/components/input.scss
+++ b/packages/taro-ui/rn/style/components/input.scss
@@ -53,16 +53,14 @@
 
   &__input {
     flex: 1;
-    //display: inline-block;
     padding-top: 0;
     padding-right: $spacing-v-md;
     padding-left: 0;
     padding-bottom: 0;
     color: $at-input-text-color;
     font-size: $at-input-font-size;
-    // height: $at-input-font-size * 1.4;
-    // line-height: $line-height-zh * $at-input-font-size;
-    line-height: 1.2 * $at-input-font-size;
+    // 设行高要兼容 placehost style，不然会弹上去
+    // line-height: 1.2 * $at-input-font-size;
     /*postcss-pxtransform rn eject enable*/
     vertical-align: middle;
     /*postcss-pxtransform rn eject disable*/

--- a/packages/taro-ui/rn/style/components/timeline.scss
+++ b/packages/taro-ui/rn/style/components/timeline.scss
@@ -16,13 +16,20 @@
     &--sub {
       color: $at-timeline-desc-color;
       font-size: $at-timeline-desc-font-size;
+      line-height: $line-height-zh * $at-timeline-desc-font-size;
+    }
+
+    &-item {
+      color: $at-timeline-title-color;
+      font-size: $at-timeline-title-font-size;
+      line-height: $line-height-zh * $at-timeline-title-font-size;
     }
   }
 
   &__dot {
     position: absolute;
     left: 0;
-    top: 0;
+    top: 8px;
     width: $at-timeline-dot-size;
     height: $at-timeline-dot-size;
     font-size: 0;


### PR DESCRIPTION
## Taro UI 支持 React native内测版本
兼容涉及到操作 DOM 包括 SwipeAction 滑动操作，Accordion手风琴，Indexes索引选择器，Calendar日历四个组件未进行适配，开发者可找第三方的组件，或者贡献自己的代码。

## 动画部分
缺失动画的组件包括，SearchBar搜索栏，Tabs标签页组件，待完善。

## 非 React Native 部分
非 React Native 代码未进行更改，新建目录：
- packages/taro-ui/rn/*
- packages/taro-ui-demo-rn

## 快速预览
https://github.com/wuba/taro-ui-rn/releases/tag/v3.1.0-beta.1