### PR TITLE
chore(release): publish 3.1.0-beta.2

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -13,6 +13,6 @@
       "license": "MIT"
     }
   },
-  "version": "3.1.0-beta.1",
+  "version": "3.1.0-beta.2",
   "npmClient": "yarn"
 }

--- a/packages/taro-ui-demo-rn/package.json
+++ b/packages/taro-ui-demo-rn/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "taro-ui-demo-rn",
-  "version": "3.1.0-beta.1",
+  "version": "3.1.0-beta.2",
   "description": "Taro UI demo",
   "author": "O2Team <aotu.io>",
   "homepage": "https://taro-ui.aotu.io",
@@ -52,7 +52,7 @@
     "react-dom": "^16.13.0",
     "react-native": "^0.66.0",
     "react-native-modal": "^13.0.0",
-    "taro-ui": "^3.1.0-beta.1"
+    "taro-ui": "3.1.0-beta.2"
   },
   "devDependencies": {
     "@babel/core": "^7.8.0",

--- a/packages/taro-ui-demo/package.json
+++ b/packages/taro-ui-demo/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "taro-ui-demo",
-  "version": "3.1.0-beta.1",
+  "version": "3.1.0-beta.2",
   "description": "Taro UI demo",
   "author": "O2Team <aotu.io>",
   "homepage": "https://taro-ui.aotu.io",
@@ -48,7 +48,7 @@
     "@tarojs/taro": "~3.3.20",
     "react": "^16.13.0",
     "react-dom": "^16.13.0",
-    "taro-ui": "^3.1.0-beta.1"
+    "taro-ui": "3.1.0-beta.2"
   },
   "devDependencies": {
     "@babel/core": "^7.8.0",

--- a/packages/taro-ui-demo/yarn.lock
+++ b/packages/taro-ui-demo/yarn.lock
@@ -12195,15 +12195,6 @@ taro-css-to-react-native@^2.0.4:
     css-mediaquery "^0.1.2"
     postcss-value-parser "^3.3.0"
 
-"taro-ui@file:../taro-ui":
-  version "3.1.0-beta.1"
-  dependencies:
-    classnames "^2.2.6"
-    dayjs "^1.7.7"
-    lodash "^4.17.10"
-    prop-types "^15.7.2"
-    react-native-modal "^13.0.0"
-
 term-size@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/term-size/-/term-size-1.2.0.tgz#458b83887f288fc56d6fffbfad262e26638efa69"

--- a/packages/taro-ui/package.json
+++ b/packages/taro-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "taro-ui",
-  "version": "3.1.0-beta.1",
+  "version": "3.1.0-beta.2",
   "description": "UI KIT for Taro",
   "module": "dist/index.esm.js",
   "main": "dist/index.js",


### PR DESCRIPTION
## Taro UI 支持 React native内测版本
兼容涉及到操作 DOM 包括 SwipeAction 滑动操作，Accordion手风琴，Indexes索引选择器，Calendar日历四个组件未进行适配，开发者可找第三方的组件，或者贡献自己的代码。

## 动画部分
缺失动画的组件包括，SearchBar搜索栏，Tabs标签页组件，待完善。

## 非 React Native 部分
非 React Native 代码未进行更改，新建目录：
- packages/taro-ui/rn/*
- packages/taro-ui-demo-rn

## 快速预览
https://github.com/NervJS/taro-ui/releases 找到二维码

下载 [taro-playground](https://github.com/wuba/taro-playground) 扫一扫尝试
