### PR TITLE
Add accordion.d.ts children? attribute to avoid type error prompt

### DIFF
--- a/packages/taro-ui/types/accordion.d.ts
+++ b/packages/taro-ui/types/accordion.d.ts
@@ -37,6 +37,10 @@ export interface AtAccordionProps extends AtComponent {
    * 点击头部触发事件
    */
   onClick?: (open: boolean, event: CommonEvent) => void
+  /**
+   * 可选子节点
+   */
+  children?: React.ReactNode
 }
 
 export interface AtAccordionState {


### PR DESCRIPTION
Fix #1515

增加 children?: React.ReactNode 属性，避免 tsx 下报类似 “TS2322: Type '{ children: Element; current: number; index: number; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<AtTabsPaneProps, any, any>> & Readonly<...>'.   Property 'children' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<AtTabsPaneProps, any, any>> & Readonly<...>'. ” 的错误。
