### PR TITLE
Add curtain.d.ts children? attribute to avoid type error prompt

### DIFF
--- a/packages/taro-ui/types/curtain.d.ts
+++ b/packages/taro-ui/types/curtain.d.ts
@@ -19,6 +19,10 @@ export interface AtCurtainProps extends AtComponent {
    * 点击关闭按钮触发事件
    */
   onClose: CommonEventFunction
+  /**
+   * 可选子节点
+   */
+  children?: React.ReactNode
 }
 
 declare const AtCurtain: ComponentClass<AtCurtainProps>


### PR DESCRIPTION
Fix: #1515

Type error prompt like: 

> Type '{ children: string; marquee: true; speed: number; icon: string; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<AtNoticeBarProps, any, any>> & Readonly<...>'. Property 'children' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<AtNoticeBarProps, any, any>> & Readonly<...>'.ts(2322)