### PR TITLE
Update base.d.ts

### DIFF
--- a/packages/taro-ui/types/base.d.ts
+++ b/packages/taro-ui/types/base.d.ts
@@ -1,9 +1,10 @@
-import { CSSProperties } from 'react'
+import { CSSProperties, ReactNode } from 'react'
 
 export interface AtComponent {
   className?: string
   style?: CSSProperties
   customStyle?: string | CSSProperties
+  children?: ReactNode | undefined
 }
 
 export interface AtIconBaseProps2 extends AtComponent {


### PR DESCRIPTION
fix the ts type error caused by the actual children declaration of each component in vscode and other IDEs