### PR TITLE
修正 taro 官网地址

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Taro 是由 [凹凸实验室](https://aotu.io) 倾力打造的多端开发解决
 
 - [Taro UI 使用文档](https://taro-ui.aotu.io)
 - [Taro UI 官方示例](https://github.com/NervJS/taro-ui-demo)
-- [Taro](https://taro.aotu.io/)
+- [Taro](https://taro.jd.com/)
 - [Taro 物料市场](https://taro-ext.jd.com)
 - [Taro 论坛 Taro-UI 板块](https://taro-club.jd.com/category/11/taro-ui)
 

--- a/packages/taro-ui-docs/markdown/introduction.md
+++ b/packages/taro-ui-docs/markdown/introduction.md
@@ -2,7 +2,7 @@
 
 ----
 
-`Taro UI` 是一款基于 [Taro](https://taro.aotu.io) 框架开发的多端 UI 组件库
+`Taro UI` 是一款基于 [Taro](https://taro.jd.com/) 框架开发的多端 UI 组件库
 
 ## Taro
 


### PR DESCRIPTION
https://taro.aotu.io/ 页面进去后显示的是 O2 Lab，只在页脚展示了 taro 官网的入口。