### PR TITLE
fix: 修复无法动态更改倒计时问题

### DIFF
--- a/packages/taro-ui/src/components/countdown/index.tsx
+++ b/packages/taro-ui/src/components/countdown/index.tsx
@@ -55,6 +55,7 @@ export default class AtCountdown extends React.Component<
   private clearTimer(): void {
     if (this.timer) {
       clearTimeout(this.timer as number)
+      this.timer = 0
     }
   }
 
@@ -127,14 +128,9 @@ export default class AtCountdown extends React.Component<
   }
 
   public render(): JSX.Element {
-    const {
-      className,
-      customStyle,
-      format,
-      isShowDay,
-      isCard,
-      isShowHour
-    } = this.props
+    const { className, customStyle, format, isShowDay, isCard, isShowHour } =
+      this.props
+
     const { _day, _hours, _minutes, _seconds } = this.state
 
     return (


### PR DESCRIPTION
this.timer 未置空，初始化后无法重新计时