### PR TITLE
chore: 修复在Windows环境下样式文件拷贝的路径分隔符问题

### DIFF
--- a/packages/taro-ui/config/rollup.config.js
+++ b/packages/taro-ui/config/rollup.config.js
@@ -9,7 +9,8 @@ import iconsMaker from './iconsMaker.js'
 
 iconsMaker('../rn/assets/iconfont.svg')
 
-const resolveFile = path => NodePath.resolve(__dirname, '..', path)
+const resolveFile = path =>
+  NodePath.resolve(__dirname, '..', path).split(NodePath.sep).join('/')
 
 const externalPackages = [
   'react',


### PR DESCRIPTION
解决了在Windows环境下的路径分隔符问题，该问题导致样式文件无法正确拷贝。