### PR TITLE
feat: 修复在indexes组件中使用了toast组件导致点击索引值时不响应

### DIFF
--- a/packages/taro-ui/src/components/toast/index.tsx
+++ b/packages/taro-ui/src/components/toast/index.tsx
@@ -142,7 +142,7 @@ export default class AtToast extends React.Component<
           </View>
         </View>
       </View>
-    ) : null
+    ) : <View>{null}</View>
   }
 }
 


### PR DESCRIPTION
您好，我为Toast组件增加了<View>{null}</View>空元素占位。
在Indexes组件中渲染Toast组件时，null导致页面重排，在结合ScrollView组件使用过程中，导致v3.3.0 indexes组件BUG #1826这个bug产生

期待您的回复，祝您今天愉快~
