### PR TITLE
chore(release): publish 3.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "taro-ui",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "UI KIT for Taro",
   "author": "O2Team <aotu.io>",
   "homepage": "https://jd-opensource.github.io/taro-ui/#/",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "private": true,
   "name": "taro-ui",
+  "version": "3.3.0",
   "description": "UI KIT for Taro",
   "author": "O2Team <aotu.io>",
   "homepage": "https://jd-opensource.github.io/taro-ui/#/",

--- a/packages/taro-ui-demo-rn/package.json
+++ b/packages/taro-ui-demo-rn/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "taro-ui-demo-rn",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "Taro UI demo",
   "author": "O2Team <aotu.io>",
   "homepage": "https://jd-opensource.github.io/taro-ui/#/",

--- a/packages/taro-ui-demo/package.json
+++ b/packages/taro-ui-demo/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "taro-ui-demo",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "Taro UI demo",
   "author": "O2Team <aotu.io>",
   "homepage": "https://jd-opensource.github.io/taro-ui/#/",

--- a/packages/taro-ui-docs/package.json
+++ b/packages/taro-ui-docs/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "taro-ui-docs",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "Taro UI docs",
   "author": "O2Team <aotu.io>",
   "homepage": "https://jd-opensource.github.io/taro-ui/#/",

--- a/packages/taro-ui/package.json
+++ b/packages/taro-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "taro-ui",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "UI KIT for Taro",
   "module": "dist/index.esm.js",
   "main": "dist/index.js",


### PR DESCRIPTION
## Bug Fixes

* **avatar:** avoid static OpenData import to fix xhs platform build error ([#1842](https://github.com/jd-opensource/taro-ui/issues/1842))
* **deps:** mark react-native as optional peer dependency to resolve npm ERESOLVE conflict ([#1843](https://github.com/jd-opensource/taro-ui/issues/1843))
* **toast:** fix enterprise WeChat compilation by removing OpenData and correcting calc() syntax ([#1844](https://github.com/jd-opensource/taro-ui/issues/1844))

## [3.3.1](https://github.com/jd-opensource/taro-ui/compare/v3.3.0...v3.3.1) (2026-04-22)