### PR TITLE
chore(release): publish 3.3.1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,7 @@ on:
 
 env:
   CI: true
+  NODE_OPTIONS: --openssl-legacy-provider
 permissions: {}
 jobs:
   publish:


### PR DESCRIPTION
修复 publish workflow 的 OpenSSL 错误，重新触发 3.3.1 发布。