### PR TITLE
chore(release): publish 3.3.2

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - 'chore/**'
       - 'feat/**'
+      - next
   pull_request:
     branches:
       - next
@@ -60,7 +61,7 @@ jobs:
         uses: andymckay/cancel-action@0.3
 
       - name: Publish push tag verification
-        if: github.event_name == 'push' && contains( env.COMMIT_MESSAGE , '--tag=' ) != true
+        if: github.event_name == 'push' && github.ref_name != 'next' && contains( env.COMMIT_MESSAGE , '--tag=' ) != true
         uses: andymckay/cancel-action@0.3
 
       # Get & check npm publish
@@ -102,7 +103,7 @@ jobs:
       # ------------------ If git tag already exists, skip -------------
 
       - name: Git tag verification
-        if: steps.tag_check.outputs.exists_tag == false
+        if: steps.tag_check.outputs.exists_tag == 'true'
         uses: andymckay/cancel-action@0.3
 
       # Bootstrap project


### PR DESCRIPTION
修复 publish CI 并触发 3.3.2 发布。

### 变更
- 修复 `.github/workflows/publish.yml`：
  - push 触发分支增加 `next`，避免直接 push next 时无法触发发布
  - next 分支的 release commit 不再强制要求 `--tag=` 参数
  - 修复 `exists_tag` 布尔值字符串比较（`== false` → `== 'true'`）

### 说明
v3.3.2 的 tag 已存在但 npm 未发布，通过此 PR 合并后触发 CI publish。