### PR TITLE
refactor(components): migrate all taro-ui components from class to function components

### DIFF
--- a/docs/MIGRATION_FC.md
+++ b/docs/MIGRATION_FC.md
@@ -10,10 +10,21 @@
 
 ## 迁移状态
 
-| 状态 | 组件 |
+| 状态 | 说明 |
 |------|------|
-| 已完成 | `loading`、`button` |
-| 待迁移 | 其余 `src/components/**/index.tsx` 中仍为 `class` 的组件（约 60+） |
+| **已完成** | `packages/taro-ui/src/components` 下全部 **58** 个组件入口（含子组件）均已改为 Function 组件 |
+| 验证 | `pnpm run build:ui` + `cd packages/taro-ui && pnpm test`（**354** 项测试、**314** 快照） |
+
+`src/components` 内已无 `export default class`。`src/common/component.tsx` 中的 `AtComponent` 基类仍保留（无组件继承，仅对外 export）。
+
+### 分阶段记录（历史）
+
+| 阶段 | 范围 |
+|------|------|
+| PR-1 | 展示类：`divider`、`tag`、`badge`、`progress`、`icon`、`card`、`steps`、`timeline`、`curtain`、`load-more`、`activity-indicator`、`segmented-control`、`form`、`list`、`flex`、`tabs-pane`、`grid`、`rate`、`radio`、`checkbox`、`switch`、`fab`、`nav-bar` 及 modal/action-sheet/countdown/swipe-action 子组件、`avatar` |
+| PR-2 | `input`（`useRef` 保存 `inputClearing`）、`textarea`、`input-number`、`image-picker` |
+| PR-3 | `modal`、`action-sheet`、`accordion`、`drawer`、`float-layout`、`pagination`、`tabs`、`slider`、`range`、`search-bar`、`tab-bar`、`toast`、`message`、`indexes`、`swipe-action`、`noticebar`、`countdown` |
+| PR-4 | `calendar` 子树：`ui/day-list`、`ui/date-list`、`controller`、`body`、`index` |
 
 ## 基本步骤
 

--- a/docs/MIGRATION_FC.md
+++ b/docs/MIGRATION_FC.md
@@ -1,0 +1,214 @@
+# Class 组件 → Function 组件迁移指南
+
+本文档说明如何将 `packages/taro-ui` 中的 Class 组件迁移为 Function 组件（FC），并保持对外 API、运行时行为与测试快照一致。
+
+## 目标
+
+- 统一组件实现为 Function 组件，便于维护与后续 React 版本兼容
+- **不改变**对外 props、DOM 结构、样式 class、事件语义
+- 每个组件单独 PR，必须通过对应 `test/components/*.test.js`
+
+## 迁移状态
+
+| 状态 | 组件 |
+|------|------|
+| 已完成 | `loading`、`button` |
+| 待迁移 | 其余 `src/components/**/index.tsx` 中仍为 `class` 的组件（约 60+） |
+
+## 基本步骤
+
+1. 阅读 `src/components/<name>/index.tsx` 与 `test/components/<name>.test.js`
+2. 按本文约定改写为 Function 组件
+3. 根目录执行构建：`pnpm run build:ui`
+4. 在 `packages/taro-ui` 下跑测试：`pnpm exec jest test/components/<name>.test.js --no-coverage`
+5. 快照失败时先确认是否为**非预期**行为变化；仅当 DOM/样式确实应与旧版一致时再更新快照
+
+## 代码约定
+
+### 1. 组件声明
+
+```tsx
+// 之前
+export default class AtXxx extends React.Component<AtXxxProps, AtXxxState> {
+  public render(): JSX.Element { ... }
+}
+
+// 之后
+function AtXxx(props: AtXxxProps): JSX.Element { ... }
+
+AtXxx.propTypes = { ... }
+
+export default AtXxx
+```
+
+- 移除 `public static defaultProps`、`public static propTypes` 类静态声明
+- 类型仍从 `packages/taro-ui/types/<name>.d.ts` 引用（如 `AtButtonProps`）
+- 无 state 的组件可删除 `AtXxxState` 的 import（类型文件中的 `State` 接口可保留，供历史类型导出）
+
+### 2. 默认值：`defaultProps` → 解构默认参数
+
+React 18+ 不推荐在 Function 组件上使用 `defaultProps`，统一改为参数解构默认值：
+
+```tsx
+// 之前
+AtLoading.defaultProps = { size: 0, color: '' }
+
+// 之后
+function AtLoading({ color = '', size = 0 }: AtLoadingProps): JSX.Element {
+```
+
+将原 `defaultProps` 中的每一项映射到函数参数默认值；未在 `defaultProps` 中声明的 prop 保持可选，不设默认参数。
+
+### 3. 保留 `propTypes`
+
+`propTypes` 继续挂在函数组件上，构建产物中会保留（`tsup` 不会剥离）：
+
+```tsx
+AtLoading.propTypes = {
+  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  color: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+}
+```
+
+| 环境 | 是否校验 |
+|------|----------|
+| 开发 / `NODE_ENV=test` | 是，`console.error` 输出 Failed prop type |
+| 生产 `NODE_ENV=production` | 否（React 跳过运行时校验） |
+
+TypeScript 的 `interface` 与 `propTypes` 互补，迁移时**不要删除** `propTypes` 块。
+
+### 4. 实例方法 → 函数内 handler
+
+```tsx
+// 之前
+private onClick(event: CommonEvent): void {
+  if (!this.props.disabled) {
+    this.props.onClick && this.props.onClick(event)
+  }
+}
+// JSX: onClick={this.onClick.bind(this)}
+
+// 之后
+const handleClick = (event: CommonEvent): void => {
+  if (!disabled) {
+    onClick && onClick(event)
+  }
+}
+// JSX: onClick={handleClick}
+```
+
+- 在参数解构后直接使用 `disabled`、`onClick` 等，无需 `bind`
+- 命名建议：`handleClick`、`handleGetUserInfo`（与私有方法 `onClick` 区分，避免与 props 同名遮蔽）
+
+### 5. `constructor` / `state` 的处理
+
+#### 仅初始化环境等「不变」数据（参考 `button`）
+
+原在 `constructor` 中根据 `Taro.getEnv()` 写入 state：
+
+```tsx
+// 之前
+this.state = {
+  isWEB: Taro.getEnv() === Taro.ENV_TYPE.WEB,
+  ...
+}
+
+// 之后（每次 render 计算即可，env 在实例生命周期内不变）
+const isWEB = Taro.getEnv() === Taro.ENV_TYPE.WEB
+const isWEAPP = Taro.getEnv() === Taro.ENV_TYPE.WEAPP
+const isALIPAY = Taro.getEnv() === Taro.ENV_TYPE.ALIPAY
+```
+
+测试环境通过 `test/__mock__/taro.js` 将 `getEnv()` 固定为 `WEB`，行为与迁移前一致。
+
+#### 真正的 UI state（`setState`）
+
+需改为 `useState` / `useReducer`，并核对：
+
+- `componentDidMount` / `componentWillUnmount` → `useEffect`
+- `componentWillReceiveProps` / `UNSAFE_*` → `useEffect` + 依赖项
+
+**有生命周期或复杂 state 的组件**（如 `message`、`toast`、`calendar`）应单独评估，不要机械替换。
+
+### 6. `render` 中的解构
+
+将 `render()` 内对 `this.props` 的解构上移到函数参数；逻辑保持逐行等价，避免顺带重构。
+
+### 7. TypeScript 注意点
+
+**`type` 等 prop 允许空字符串但类型未包含 `''`**
+
+`AtButton` 原在 `render` 里写 `type = ''`，而 `AtButtonProps['type']` 仅为 `'primary' | 'secondary'`。迁移时可：
+
+```tsx
+function AtButton({ type, ... }: AtButtonProps) {
+  const buttonType = type ?? ''
+  const classObject = {
+    [`at-button--${buttonType}`]: buttonType
+      ? TYPE_CLASS[buttonType as keyof typeof TYPE_CLASS]
+      : false
+  }
+}
+```
+
+不要在参数上写 `type = ''`，否则会触发 `TS2322`。
+
+**索引 `TYPE_CLASS[type]`**
+
+`type` 为 `undefined` 时不能直接作为索引，需先收窄或使用 `buttonType` 辅助变量（见上）。
+
+### 8. 不要改动的部分
+
+- 对外导出名、`className` 前缀、`packages/taro-ui/types/*.d.ts` 中的公共 props（除非类型本就错误且单独立项修复）
+- SCSS、`dist` 构建配置、组件在 `src/index.ts` 中的导出路径
+- 测试用例的断言逻辑（除非修复测试本身 bug）
+
+## 参考实现
+
+### 无 state：`loading`
+
+路径：`packages/taro-ui/src/components/loading/index.tsx`
+
+要点：解构默认值、`propTypes`、纯展示逻辑。
+
+### 构造函数 state + 事件：`button`
+
+路径：`packages/taro-ui/src/components/button/index.tsx`
+
+要点：`Taro.getEnv()`、多平台 `Button` 子节点、`AtLoading` 子组件、disabled 时阻止 `onClick`。
+
+## 测试说明
+
+- 测试入口：`packages/taro-ui/test/components/<name>.test.js`
+- import 路径 `../../lib/components/...` 经 Jest `moduleNameMapper` 映射到 **`dist/`**，因此**必须先** `pnpm run build:ui`
+- 常见用例：快照（`toMatchSnapshot`）、`fireEvent` + `queryByClass`
+- 跑单个文件：
+
+```bash
+cd packages/taro-ui
+pnpm exec jest test/components/button.test.js --no-coverage
+```
+
+- 更新快照（确认无行为回归后）：
+
+```bash
+pnpm run test:update -- test/components/button.test.js
+```
+
+## PR 检查清单
+
+- [ ] 仅修改目标组件及相关必要类型，diff 尽量小
+- [ ] `pnpm run build:ui` 成功
+- [ ] 对应 `*.test.js` 全部通过
+- [ ] 未引入 `defaultProps`（Function 组件）
+- [ ] `propTypes` 与原 class 组件一致
+- [ ] 有 `setState` / 生命周期的组件已单独说明 Hook 方案（或暂不迁移并备注原因）
+
+## 建议迁移顺序
+
+1. **简单展示类**：`divider`、`tag`、`badge`、`progress`、`icon` …
+2. **仅 props + 事件**：`checkbox`、`radio`、`switch`、`fab` …
+3. **含子组件拼装**：`list`、`modal`、`action-sheet` …
+4. **含 state / 副作用**：`message`、`toast`、`indexes`、`calendar` …
+
+优先迁移已有测试且快照稳定的组件，降低回归风险。

--- a/packages/taro-ui/src/common/utils.ts
+++ b/packages/taro-ui/src/common/utils.ts
@@ -268,6 +268,9 @@ function isJSXElement(props, propName, componentName) {
   }
 }
 
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+function noop(): void {}
+
 export {
   delay,
   delayQuerySelector,
@@ -280,5 +283,6 @@ export {
   delayGetClientRect,
   delayGetScrollOffset,
   mergeStyle,
-  isJSXElement
+  isJSXElement,
+  noop
 }

--- a/packages/taro-ui/src/components/accordion/index.tsx
+++ b/packages/taro-ui/src/components/accordion/index.tsx
@@ -25,15 +25,15 @@ function AtAccordion({
   const [, setRenderEpoch] = useState(0)
   const prevOpenRef = useRef(open)
 
-  const toggleWithAnimation = (): void => {
+  const toggleWithAnimation = (wasOpen: boolean): void => {
     if (!isCompletedRef.current || !isAnimation) return
 
     isCompletedRef.current = false
 
     delayQuerySelector(`#at-accordion__body-${componentId}`, 0).then(rect => {
       const height = parseInt(rect[0].height.toString())
-      const startHeight = open ? height : 0
-      const endHeight = open ? 0 : height
+      const startHeight = wasOpen ? height : 0
+      const endHeight = wasOpen ? 0 : height
       setStartOpen(false)
       setWrapperHeight(startHeight)
       setTimeout(() => {
@@ -49,7 +49,7 @@ function AtAccordion({
   useLayoutEffect(() => {
     if (prevOpenRef.current !== open) {
       setStartOpen(!!open && !!isAnimation)
-      toggleWithAnimation()
+      toggleWithAnimation(prevOpenRef.current)
       prevOpenRef.current = open
     }
   }, [open, isAnimation])

--- a/packages/taro-ui/src/components/accordion/index.tsx
+++ b/packages/taro-ui/src/components/accordion/index.tsx
@@ -1,150 +1,116 @@
 import classNames from 'classnames'
-import PropTypes, { InferProps } from 'prop-types'
-import React from 'react'
+import PropTypes from 'prop-types'
+import React, { useLayoutEffect, useRef, useState } from 'react'
 import { Text, View } from '@tarojs/components'
 import { CommonEvent } from '@tarojs/components/types/common'
-import { AtAccordionProps, AtAccordionState } from '../../../types/accordion'
+import { AtAccordionProps } from '../../../types/accordion'
 import { delayQuerySelector, uuid } from '../../common/utils'
 
-export default class AtAccordion extends React.Component<
-  AtAccordionProps,
-  AtAccordionState
-> {
-  private isCompleted: boolean
-  private startOpen: boolean
+function AtAccordion({
+  open = false,
+  customStyle = '',
+  className = '',
+  title = '',
+  note = '',
+  icon = { value: '' },
+  hasBorder = true,
+  isAnimation = true,
+  children,
+  onClick
+}: AtAccordionProps): JSX.Element {
+  const isCompletedRef = useRef(true)
+  const [componentId] = useState(() => uuid())
+  const [wrapperHeight, setWrapperHeight] = useState(0)
+  const [startOpen, setStartOpen] = useState(false)
+  const [, setRenderEpoch] = useState(0)
+  const prevOpenRef = useRef(open)
 
-  public static defaultProps: AtAccordionProps
-  public static propTypes: InferProps<AtAccordionProps>
+  const toggleWithAnimation = (): void => {
+    if (!isCompletedRef.current || !isAnimation) return
 
-  public constructor(props: AtAccordionProps) {
-    super(props)
-    this.isCompleted = true
-    this.startOpen = false
-    this.state = {
-      componentId: uuid(),
-      wrapperHeight: 0
-    }
-  }
-
-  private handleClick = (event: CommonEvent): void => {
-    const { open } = this.props
-    if (!this.isCompleted) return
-
-    this.props.onClick && this.props.onClick(!open, event)
-  }
-
-  private toggleWithAnimation(): void {
-    const { open, isAnimation } = this.props
-    const { componentId } = this.state
-    if (!this.isCompleted || !isAnimation) return
-
-    this.isCompleted = false
+    isCompletedRef.current = false
 
     delayQuerySelector(`#at-accordion__body-${componentId}`, 0).then(rect => {
       const height = parseInt(rect[0].height.toString())
       const startHeight = open ? height : 0
       const endHeight = open ? 0 : height
-      this.startOpen = false
-      this.setState(
-        {
-          wrapperHeight: startHeight
-        },
-        () => {
-          setTimeout(() => {
-            this.setState(
-              {
-                wrapperHeight: endHeight
-              },
-              () => {
-                setTimeout(() => {
-                  this.isCompleted = true
-                  this.setState({})
-                }, 700)
-              }
-            )
-          }, 100)
-        }
-      )
+      setStartOpen(false)
+      setWrapperHeight(startHeight)
+      setTimeout(() => {
+        setWrapperHeight(endHeight)
+        setTimeout(() => {
+          isCompletedRef.current = true
+          setRenderEpoch(epoch => epoch + 1)
+        }, 700)
+      }, 100)
     })
   }
 
-  public UNSAFE_componentWillReceiveProps(nextProps: AtAccordionProps): void {
-    if (nextProps.open !== this.props.open) {
-      this.startOpen = !!nextProps.open && !!nextProps.isAnimation
-      this.toggleWithAnimation()
+  useLayoutEffect(() => {
+    if (prevOpenRef.current !== open) {
+      setStartOpen(!!open && !!isAnimation)
+      toggleWithAnimation()
+      prevOpenRef.current = open
     }
+  }, [open, isAnimation])
+
+  const handleClick = (event: CommonEvent): void => {
+    if (!isCompletedRef.current) return
+
+    onClick && onClick(!open, event)
   }
 
-  public render(): JSX.Element {
-    const { customStyle, className, title, icon, hasBorder, open, note } =
-      this.props
-    const { wrapperHeight } = this.state
+  const rootCls = classNames('at-accordion', className)
+  const prefixClass = (icon && icon.prefixClass) || 'at-icon'
+  const iconCls = classNames({
+    [prefixClass]: true,
+    [`${prefixClass}-${icon && icon.value}`]: icon && icon.value,
+    'at-accordion__icon': true
+  })
+  const headerCls = classNames('at-accordion__header', {
+    'at-accordion__header--noborder': !hasBorder
+  })
+  const arrowCls = classNames('at-accordion__arrow', {
+    'at-accordion__arrow--folded': !!open
+  })
+  const contentCls = classNames('at-accordion__content', {
+    'at-accordion__content--inactive':
+      (!open && isCompletedRef.current) || startOpen
+  })
+  const iconStyle = {
+    color: (icon && icon.color) || '',
+    fontSize: (icon && `${icon.size}px`) || ''
+  }
+  const contentStyle: { height?: string } = { height: `${wrapperHeight}px` }
 
-    const rootCls = classNames('at-accordion', className)
-    const prefixClass = (icon && icon.prefixClass) || 'at-icon'
-    const iconCls = classNames({
-      [prefixClass]: true,
-      [`${prefixClass}-${icon && icon.value}`]: icon && icon.value,
-      'at-accordion__icon': true
-    })
-    const headerCls = classNames('at-accordion__header', {
-      'at-accordion__header--noborder': !hasBorder
-    })
-    const arrowCls = classNames('at-accordion__arrow', {
-      'at-accordion__arrow--folded': !!open
-    })
-    const contentCls = classNames('at-accordion__content', {
-      'at-accordion__content--inactive':
-        (!open && this.isCompleted) || this.startOpen
-    })
-    const iconStyle = {
-      color: (icon && icon.color) || '',
-      fontSize: (icon && `${icon.size}px`) || ''
-    }
-    const contentStyle = { height: `${wrapperHeight}px` }
+  if (isCompletedRef.current) {
+    contentStyle.height = ''
+  }
 
-    if (this.isCompleted) {
-      contentStyle.height = ''
-    }
-
-    const { componentId } = this.state
-
-    return (
-      <View className={rootCls} style={customStyle}>
-        <View className={headerCls} onClick={this.handleClick}>
-          {icon && icon.value && (
-            <Text className={iconCls} style={iconStyle}></Text>
-          )}
-          <View className='at-accordion__info'>
-            <View className='at-accordion__info__title'>{title}</View>
-            <View className='at-accordion__info__note'>{note}</View>
-          </View>
-          <View className={arrowCls}>
-            <Text className='at-icon at-icon-chevron-down'></Text>
-          </View>
+  return (
+    <View className={rootCls} style={customStyle}>
+      <View className={headerCls} onClick={handleClick}>
+        {icon && icon.value && (
+          <Text className={iconCls} style={iconStyle}></Text>
+        )}
+        <View className='at-accordion__info'>
+          <View className='at-accordion__info__title'>{title}</View>
+          <View className='at-accordion__info__note'>{note}</View>
         </View>
-        <View style={contentStyle} className={contentCls}>
-          <View
-            id={`at-accordion__body-${componentId}`}
-            className='at-accordion__body'
-          >
-            {this.props.children}
-          </View>
+        <View className={arrowCls}>
+          <Text className='at-icon at-icon-chevron-down'></Text>
         </View>
       </View>
-    )
-  }
-}
-
-AtAccordion.defaultProps = {
-  open: false,
-  customStyle: '',
-  className: '',
-  title: '',
-  note: '',
-  icon: { value: '' },
-  hasBorder: true,
-  isAnimation: true
+      <View style={contentStyle} className={contentCls}>
+        <View
+          id={`at-accordion__body-${componentId}`}
+          className='at-accordion__body'
+        >
+          {children}
+        </View>
+      </View>
+    </View>
+  )
 }
 
 AtAccordion.propTypes = {
@@ -158,3 +124,5 @@ AtAccordion.propTypes = {
   hasBorder: PropTypes.bool,
   onClick: PropTypes.func
 }
+
+export default AtAccordion

--- a/packages/taro-ui/src/components/action-sheet/body/index.tsx
+++ b/packages/taro-ui/src/components/action-sheet/body/index.tsx
@@ -3,9 +3,12 @@ import React from 'react'
 import { View } from '@tarojs/components'
 import { AtActionSheetBodyProps } from '../../../../types/action-sheet'
 
-export default class AtActionSheetBody extends React.Component<AtActionSheetBodyProps> {
-  public render(): JSX.Element {
-    const rootClass = classNames('at-action-sheet__body', this.props.className)
-    return <View className={rootClass}>{this.props.children}</View>
-  }
+function AtActionSheetBody({
+  className,
+  children
+}: AtActionSheetBodyProps): JSX.Element {
+  const rootClass = classNames('at-action-sheet__body', className)
+  return <View className={rootClass}>{children}</View>
 }
+
+export default AtActionSheetBody

--- a/packages/taro-ui/src/components/action-sheet/body/item/index.tsx
+++ b/packages/taro-ui/src/components/action-sheet/body/item/index.tsx
@@ -1,30 +1,31 @@
 import classNames from 'classnames'
-import PropTypes, { InferProps } from 'prop-types'
+import PropTypes from 'prop-types'
 import React from 'react'
 import { View } from '@tarojs/components'
 import { AtActionSheetItemProps } from '../../../../../types/action-sheet'
 
-export default class AtActionSheetItem extends React.Component<AtActionSheetItemProps> {
-  public static defaultProps: AtActionSheetItemProps
-  public static propTypes: InferProps<AtActionSheetItemProps>
-
-  private handleClick = (args: any): void => {
-    if (typeof this.props.onClick === 'function') {
-      this.props.onClick(args)
+function AtActionSheetItem({
+  className,
+  children,
+  onClick
+}: AtActionSheetItemProps): JSX.Element {
+  const handleClick = (args: any): void => {
+    if (typeof onClick === 'function') {
+      onClick(args)
     }
   }
 
-  public render(): JSX.Element {
-    const rootClass = classNames('at-action-sheet__item', this.props.className)
+  const rootClass = classNames('at-action-sheet__item', className)
 
-    return (
-      <View className={rootClass} onClick={this.handleClick}>
-        {this.props.children}
-      </View>
-    )
-  }
+  return (
+    <View className={rootClass} onClick={handleClick}>
+      {children}
+    </View>
+  )
 }
 
 AtActionSheetItem.propTypes = {
   onClick: PropTypes.func
 }
+
+export default AtActionSheetItem

--- a/packages/taro-ui/src/components/action-sheet/footer/index.tsx
+++ b/packages/taro-ui/src/components/action-sheet/footer/index.tsx
@@ -1,33 +1,31 @@
 import classNames from 'classnames'
-import PropTypes, { InferProps } from 'prop-types'
+import PropTypes from 'prop-types'
 import React from 'react'
 import { View } from '@tarojs/components'
 import { AtActionSheetFooterProps } from '../../../../types/action-sheet'
 
-export default class AtActionSheetFooter extends React.Component<AtActionSheetFooterProps> {
-  public static defaultProps: AtActionSheetFooterProps
-  public static propTypes: InferProps<AtActionSheetFooterProps>
-
-  private handleClick = (...args: any[]): void => {
-    if (typeof this.props.onClick === 'function') {
-      this.props.onClick(...args)
+function AtActionSheetFooter({
+  className,
+  children,
+  onClick
+}: AtActionSheetFooterProps): JSX.Element {
+  const handleClick = (...args: any[]): void => {
+    if (typeof onClick === 'function') {
+      onClick(...args)
     }
   }
 
-  public render(): JSX.Element {
-    const rootClass = classNames(
-      'at-action-sheet__footer',
-      this.props.className
-    )
+  const rootClass = classNames('at-action-sheet__footer', className)
 
-    return (
-      <View onClick={this.handleClick} className={rootClass}>
-        {this.props.children}
-      </View>
-    )
-  }
+  return (
+    <View onClick={handleClick} className={rootClass}>
+      {children}
+    </View>
+  )
 }
 
 AtActionSheetFooter.propTypes = {
   onClick: PropTypes.func
 }
+
+export default AtActionSheetFooter

--- a/packages/taro-ui/src/components/action-sheet/header/index.tsx
+++ b/packages/taro-ui/src/components/action-sheet/header/index.tsx
@@ -3,13 +3,13 @@ import React from 'react'
 import { View } from '@tarojs/components'
 import { AtActionSheetHeaderProps } from '../../../../types/action-sheet'
 
-export default class AtActionSheetHeader extends React.Component<AtActionSheetHeaderProps> {
-  public render(): JSX.Element {
-    const rootClass = classNames(
-      'at-action-sheet__header',
-      this.props.className
-    )
+function AtActionSheetHeader({
+  className,
+  children
+}: AtActionSheetHeaderProps): JSX.Element {
+  const rootClass = classNames('at-action-sheet__header', className)
 
-    return <View className={rootClass}>{this.props.children}</View>
-  }
+  return <View className={rootClass}>{children}</View>
 }
+
+export default AtActionSheetHeader

--- a/packages/taro-ui/src/components/action-sheet/index.tsx
+++ b/packages/taro-ui/src/components/action-sheet/index.tsx
@@ -1,103 +1,85 @@
 import classNames from 'classnames'
-import PropTypes, { InferProps } from 'prop-types'
-import React from 'react'
+import PropTypes from 'prop-types'
+import React, { useEffect, useRef, useState } from 'react'
 import { View } from '@tarojs/components'
 import { CommonEvent } from '@tarojs/components/types/common'
-import {
-  AtActionSheetProps,
-  AtActionSheetState
-} from '../../../types/action-sheet'
+import { AtActionSheetProps } from '../../../types/action-sheet'
 import AtActionSheetBody from './body/index'
 import AtActionSheetFooter from './footer/index'
 import AtActionSheetHeader from './header/index'
 
-export default class AtActionSheet extends React.Component<
-  AtActionSheetProps,
-  AtActionSheetState
-> {
-  public static defaultProps: AtActionSheetProps
-  public static propTypes: InferProps<AtActionSheetProps>
+function AtActionSheet({
+  title = '',
+  cancelText = '',
+  isOpened = false,
+  className,
+  children,
+  onClose,
+  onCancel
+}: AtActionSheetProps): JSX.Element {
+  const [_isOpened, setIsOpened] = useState(isOpened)
+  const prevIsOpenedPropRef = useRef(isOpened)
 
-  public constructor(props: AtActionSheetProps) {
-    super(props)
-    const { isOpened } = props
-
-    this.state = {
-      _isOpened: isOpened
+  const handleClose = (): void => {
+    if (typeof onClose === 'function') {
+      onClose()
     }
   }
 
-  public UNSAFE_componentWillReceiveProps(nextProps: AtActionSheetProps): void {
-    const { isOpened } = nextProps
-    if (isOpened !== this.state._isOpened) {
-      this.setState({
-        _isOpened: isOpened
+  useEffect(() => {
+    if (prevIsOpenedPropRef.current !== isOpened) {
+      setIsOpened(prev => {
+        if (isOpened !== prev) {
+          if (!isOpened) {
+            handleClose()
+          }
+          return isOpened
+        }
+        return prev
       })
-
-      !isOpened && this.handleClose()
+      prevIsOpenedPropRef.current = isOpened
     }
+  }, [isOpened])
+
+  const close = (): void => {
+    setIsOpened(false)
+    handleClose()
   }
 
-  private handleClose = (): void => {
-    if (typeof this.props.onClose === 'function') {
-      this.props.onClose()
+  const handleCancel = (): void => {
+    if (typeof onCancel === 'function') {
+      return onCancel()
     }
+    close()
   }
 
-  private handleCancel = (): void => {
-    if (typeof this.props.onCancel === 'function') {
-      return this.props.onCancel()
-    }
-    this.close()
-  }
-
-  private close = (): void => {
-    this.setState(
-      {
-        _isOpened: false
-      },
-      this.handleClose
-    )
-  }
-
-  private handleTouchMove = (e: CommonEvent): void => {
+  const handleTouchMove = (e: CommonEvent): void => {
     e.stopPropagation()
     e.preventDefault()
   }
 
-  public render(): JSX.Element {
-    const { title, cancelText, className } = this.props
-    const { _isOpened } = this.state
+  const rootClass = classNames(
+    'at-action-sheet',
+    {
+      'at-action-sheet--active': _isOpened
+    },
+    className
+  )
 
-    const rootClass = classNames(
-      'at-action-sheet',
-      {
-        'at-action-sheet--active': _isOpened
-      },
-      className
-    )
-
-    return (
-      <View className={rootClass} onTouchMove={this.handleTouchMove}>
-        <View onClick={this.close} className='at-action-sheet__overlay' />
-        <View className='at-action-sheet__container'>
-          {title && <AtActionSheetHeader>{title}</AtActionSheetHeader>}
-          <AtActionSheetBody>{this.props.children}</AtActionSheetBody>
-          {cancelText && (
-            <AtActionSheetFooter onClick={this.handleCancel}>
-              {cancelText}
-            </AtActionSheetFooter>
-          )}
-        </View>
+  return (
+    <View className={rootClass} onTouchMove={handleTouchMove}>
+      <View onClick={close} className='at-action-sheet__overlay' />
+      <View className='at-action-sheet__container'>
+        {title && <AtActionSheetHeader>{title}</AtActionSheetHeader>}
+        <AtActionSheetBody>{children}</AtActionSheetBody>
+        {cancelText && (
+          <AtActionSheetFooter onClick={handleCancel}>
+            {cancelText}
+          </AtActionSheetFooter>
+        )}
       </View>
-    )
-  }
-}
-
-AtActionSheet.defaultProps = {
-  title: '',
-  cancelText: '',
-  isOpened: false
+    </View>
+  )
 }
 
 AtActionSheet.propTypes = {
@@ -107,3 +89,5 @@ AtActionSheet.propTypes = {
   isOpened: PropTypes.bool.isRequired,
   cancelText: PropTypes.string
 }
+
+export default AtActionSheet

--- a/packages/taro-ui/src/components/activity-indicator/index.tsx
+++ b/packages/taro-ui/src/components/activity-indicator/index.tsx
@@ -1,46 +1,37 @@
 import classNames from 'classnames'
-import PropTypes, { InferProps } from 'prop-types'
+import PropTypes from 'prop-types'
 import React from 'react'
 import { Text, View } from '@tarojs/components'
 import { AtActivityIndicatorProps } from '../../../types/activity-indicator'
 import AtLoading from '../loading/index'
 
-export default class AtActivityIndicator extends React.Component<AtActivityIndicatorProps> {
-  public static defaultProps: AtActivityIndicatorProps
-  public static propTypes: InferProps<AtActivityIndicatorProps>
+function AtActivityIndicator({
+  color = '',
+  size = 0,
+  mode = 'normal',
+  content = '',
+  className = '',
+  isOpened = true
+}: AtActivityIndicatorProps): JSX.Element {
+  const rootClass = classNames(
+    'at-activity-indicator',
+    {
+      'at-activity-indicator--center': mode === 'center',
+      'at-activity-indicator--isopened': isOpened
+    },
+    className
+  )
 
-  public render(): JSX.Element {
-    const { color, size, mode, content, isOpened } = this.props
-
-    const rootClass = classNames(
-      'at-activity-indicator',
-      {
-        'at-activity-indicator--center': mode === 'center',
-        'at-activity-indicator--isopened': isOpened
-      },
-      this.props.className
-    )
-
-    return (
-      <View className={rootClass}>
-        <View className='at-activity-indicator__body'>
-          <AtLoading size={size} color={color} />
-        </View>
-        {content && (
-          <Text className='at-activity-indicator__content'>{content}</Text>
-        )}
+  return (
+    <View className={rootClass}>
+      <View className='at-activity-indicator__body'>
+        <AtLoading size={size} color={color} />
       </View>
-    )
-  }
-}
-
-AtActivityIndicator.defaultProps = {
-  size: 0,
-  mode: 'normal',
-  color: '',
-  content: '',
-  className: '',
-  isOpened: true
+      {content && (
+        <Text className='at-activity-indicator__content'>{content}</Text>
+      )}
+    </View>
+  )
 }
 
 AtActivityIndicator.propTypes = {
@@ -51,3 +42,5 @@ AtActivityIndicator.propTypes = {
   className: PropTypes.oneOfType([PropTypes.array, PropTypes.string]),
   isOpened: PropTypes.bool
 }
+
+export default AtActivityIndicator

--- a/packages/taro-ui/src/components/avatar/index.tsx
+++ b/packages/taro-ui/src/components/avatar/index.tsx
@@ -1,10 +1,10 @@
 import classNames from 'classnames'
-import PropTypes, { InferProps } from 'prop-types'
+import PropTypes from 'prop-types'
 import React from 'react'
 import { Image, Text, View } from '@tarojs/components'
 import * as TaroComponents from '@tarojs/components'
 import Taro from '@tarojs/taro'
-import { AtAvatarProps, AtAvatarState } from '../../../types/avatar'
+import { AtAvatarProps } from '../../../types/avatar'
 
 const SIZE_CLASS = {
   large: 'large',
@@ -12,65 +12,49 @@ const SIZE_CLASS = {
   small: 'small'
 }
 
-export default class AtAvatar extends React.Component<
-  AtAvatarProps,
-  AtAvatarState
-> {
-  public static defaultProps: AtAvatarProps
-  public static propTypes: InferProps<AtAvatarProps>
-
-  public constructor(props: AtAvatarProps) {
-    super(props)
-    this.state = {
-      isWEAPP: Taro.getEnv() === Taro.ENV_TYPE.WEAPP
-    }
+function AtAvatar({
+  size = 'normal',
+  circle = false,
+  text = '',
+  image = '',
+  customStyle = {},
+  className = '',
+  openData
+}: AtAvatarProps): JSX.Element {
+  const isWEAPP = Taro.getEnv() === Taro.ENV_TYPE.WEAPP
+  const rootClassName = ['at-avatar']
+  const iconSize = SIZE_CLASS[size || 'normal']
+  const classObject = {
+    [`at-avatar--${iconSize}`]: iconSize,
+    'at-avatar--circle': circle
   }
 
-  public render(): JSX.Element {
-    const { size, circle, image, text, openData, customStyle } = this.props
-    const rootClassName = ['at-avatar']
-    const iconSize = SIZE_CLASS[size || 'normal']
-    const classObject = {
-      [`at-avatar--${iconSize}`]: iconSize,
-      'at-avatar--circle': circle
-    }
+  let letter = ''
+  if (text) letter = text[0]
 
-    let letter = ''
-    if (text) letter = text[0]
-
-    let elem: React.ReactNode
-    if (
-      openData &&
-      openData.type === 'userAvatarUrl' &&
-      this.state.isWEAPP &&
-      Taro.canIUse('open-data')
-    ) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const OpenData = (TaroComponents as any).OpenData
-      elem = <OpenData type={openData.type}></OpenData>
-    } else if (image) {
-      elem = <Image className='at-avatar__img' src={image} />
-    } else {
-      elem = <Text className='at-avatar__text'>{letter}</Text>
-    }
-    return (
-      <View
-        className={classNames(rootClassName, classObject, this.props.className)}
-        style={customStyle}
-      >
-        {elem}
-      </View>
-    )
+  let elem: React.ReactNode
+  if (
+    openData &&
+    openData.type === 'userAvatarUrl' &&
+    isWEAPP &&
+    Taro.canIUse('open-data')
+  ) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const OpenData = (TaroComponents as any).OpenData
+    elem = <OpenData type={openData.type}></OpenData>
+  } else if (image) {
+    elem = <Image className='at-avatar__img' src={image} />
+  } else {
+    elem = <Text className='at-avatar__text'>{letter}</Text>
   }
-}
-
-AtAvatar.defaultProps = {
-  size: 'normal',
-  circle: false,
-  text: '',
-  image: '',
-  customStyle: {},
-  className: ''
+  return (
+    <View
+      className={classNames(rootClassName, classObject, className)}
+      style={customStyle}
+    >
+      {elem}
+    </View>
+  )
 }
 
 AtAvatar.propTypes = {
@@ -82,3 +66,5 @@ AtAvatar.propTypes = {
   customStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
   className: PropTypes.oneOfType([PropTypes.array, PropTypes.string])
 }
+
+export default AtAvatar

--- a/packages/taro-ui/src/components/badge/index.tsx
+++ b/packages/taro-ui/src/components/badge/index.tsx
@@ -1,59 +1,43 @@
 import classNames from 'classnames'
-import PropTypes, { InferProps } from 'prop-types'
+import PropTypes from 'prop-types'
 import React from 'react'
 import { View } from '@tarojs/components'
 import { AtBadgeProps } from '../../../types/badge'
 
-export default class AtBadge extends React.Component<AtBadgeProps> {
-  public static defaultProps: AtBadgeProps
-  public static propTypes: InferProps<AtBadgeProps>
-
-  public constructor(props: AtBadgeProps) {
-    super(props)
-    this.state = {}
+function formatValue(
+  value: string | number | undefined,
+  maxValue: number
+): string | number {
+  if (value === '' || value === null || typeof value === 'undefined') return ''
+  const numValue = +value
+  if (Number.isNaN(numValue)) {
+    return value
   }
-
-  private formatValue(
-    value: string | number | undefined,
-    maxValue: number
-  ): string | number {
-    if (value === '' || value === null || typeof value === 'undefined')
-      return ''
-    const numValue = +value
-    if (Number.isNaN(numValue)) {
-      return value
-    }
-    return numValue > maxValue ? `${maxValue}+` : numValue
-  }
-
-  public render(): JSX.Element {
-    const { dot, value, maxValue = 99, customStyle } = this.props
-    const rootClassName = ['at-badge']
-
-    const val = this.formatValue(value, maxValue)
-
-    return (
-      <View
-        className={classNames(rootClassName, this.props.className)}
-        style={customStyle}
-      >
-        {this.props.children}
-        {dot ? (
-          <View className='at-badge__dot'></View>
-        ) : (
-          val !== '' && <View className='at-badge__num'>{val}</View>
-        )}
-      </View>
-    )
-  }
+  return numValue > maxValue ? `${maxValue}+` : numValue
 }
 
-AtBadge.defaultProps = {
-  dot: false,
-  value: '',
-  maxValue: 99,
-  customStyle: {},
-  className: ''
+export default function AtBadge({
+  dot = false,
+  value = '',
+  maxValue = 99,
+  customStyle = {},
+  className = '',
+  children
+}: AtBadgeProps): JSX.Element {
+  const rootClassName = ['at-badge']
+
+  const val = formatValue(value, maxValue)
+
+  return (
+    <View className={classNames(rootClassName, className)} style={customStyle}>
+      {children}
+      {dot ? (
+        <View className='at-badge__dot'></View>
+      ) : (
+        val !== '' && <View className='at-badge__num'>{val}</View>
+      )}
+    </View>
+  )
 }
 
 AtBadge.propTypes = {

--- a/packages/taro-ui/src/components/button/index.tsx
+++ b/packages/taro-ui/src/components/button/index.tsx
@@ -1,11 +1,11 @@
 import classNames from 'classnames'
-import PropTypes, { InferProps } from 'prop-types'
+import PropTypes from 'prop-types'
 import React from 'react'
 import { Button, View } from '@tarojs/components'
 import { ButtonProps } from '@tarojs/components/types/Button'
 import { BaseEventOrig, CommonEvent } from '@tarojs/components/types/common'
 import Taro from '@tarojs/taro'
-import { AtButtonProps, AtButtonState } from '../../../types/button'
+import { AtButtonProps } from '../../../types/button'
 import AtLoading from '../loading/index'
 
 const SIZE_CLASS = {
@@ -18,150 +18,129 @@ const TYPE_CLASS = {
   secondary: 'secondary'
 }
 
-export default class AtButton extends React.Component<
-  AtButtonProps,
-  AtButtonState
-> {
-  public static defaultProps: AtButtonProps
-  public static propTypes: InferProps<AtButtonProps>
+function AtButton({
+  size = 'normal',
+  type,
+  circle = false,
+  full = false,
+  loading = false,
+  disabled = false,
+  customStyle = {},
+  className,
+  children,
+  formType,
+  openType,
+  lang = 'en',
+  sessionFrom = '',
+  sendMessageTitle = '',
+  sendMessagePath = '',
+  sendMessageImg = '',
+  showMessageCard = false,
+  appParameter = '',
+  onClick,
+  onGetUserInfo,
+  onContact,
+  onGetPhoneNumber,
+  onError,
+  onOpenSetting
+}: AtButtonProps): JSX.Element {
+  const isWEB = Taro.getEnv() === Taro.ENV_TYPE.WEB
+  const isWEAPP = Taro.getEnv() === Taro.ENV_TYPE.WEAPP
+  const isALIPAY = Taro.getEnv() === Taro.ENV_TYPE.ALIPAY
 
-  public constructor(props: AtButtonProps) {
-    super(props)
-    this.state = {
-      isWEB: Taro.getEnv() === Taro.ENV_TYPE.WEB,
-      isWEAPP: Taro.getEnv() === Taro.ENV_TYPE.WEAPP,
-      isALIPAY: Taro.getEnv() === Taro.ENV_TYPE.ALIPAY
+  const handleClick = (event: CommonEvent): void => {
+    if (!disabled) {
+      onClick && onClick(event)
     }
   }
 
-  private onClick(event: CommonEvent): void {
-    if (!this.props.disabled) {
-      this.props.onClick && this.props.onClick(event)
-    }
+  const handleGetUserInfo = (event: CommonEvent): void => {
+    onGetUserInfo && onGetUserInfo(event)
   }
 
-  private onGetUserInfo(event: CommonEvent): void {
-    this.props.onGetUserInfo && this.props.onGetUserInfo(event)
-  }
-
-  private onContact(
+  const handleContact = (
     event: BaseEventOrig<ButtonProps.onContactEventDetail>
-  ): void {
-    this.props.onContact && this.props.onContact(event)
+  ): void => {
+    onContact && onContact(event)
   }
 
-  private onGetPhoneNumber(event: CommonEvent): void {
-    this.props.onGetPhoneNumber && this.props.onGetPhoneNumber(event)
+  const handleGetPhoneNumber = (event: CommonEvent): void => {
+    onGetPhoneNumber && onGetPhoneNumber(event)
   }
 
-  private onError(event: CommonEvent): void {
-    this.props.onError && this.props.onError(event)
+  const handleError = (event: CommonEvent): void => {
+    onError && onError(event)
   }
 
-  private onOpenSetting(event: CommonEvent): void {
-    this.props.onOpenSetting && this.props.onOpenSetting(event)
+  const handleOpenSetting = (event: CommonEvent): void => {
+    onOpenSetting && onOpenSetting(event)
   }
 
-  public render(): JSX.Element {
-    const {
-      size = 'normal',
-      type = '',
-      circle,
-      full,
-      loading,
-      disabled,
-      customStyle,
-      formType,
-      openType,
-      lang,
-      sessionFrom,
-      sendMessageTitle,
-      sendMessagePath,
-      sendMessageImg,
-      showMessageCard,
-      appParameter
-    } = this.props
-    const { isWEAPP, isALIPAY, isWEB } = this.state
-    const rootClassName = ['at-button']
-    const classObject = {
-      [`at-button--${SIZE_CLASS[size]}`]: SIZE_CLASS[size],
-      'at-button--disabled': disabled,
-      [`at-button--${type}`]: TYPE_CLASS[type],
-      'at-button--circle': circle,
-      'at-button--full': full
-    }
-    const loadingColor = type === 'primary' ? '#fff' : ''
-    const loadingSize = size === 'small' ? '30' : 0
+  const buttonType = type ?? ''
+  const rootClassName = ['at-button']
+  const classObject = {
+    [`at-button--${SIZE_CLASS[size]}`]: SIZE_CLASS[size],
+    'at-button--disabled': disabled,
+    [`at-button--${buttonType}`]: buttonType
+      ? TYPE_CLASS[buttonType as keyof typeof TYPE_CLASS]
+      : false,
+    'at-button--circle': circle,
+    'at-button--full': full
+  }
+  const loadingColor = type === 'primary' ? '#fff' : ''
+  const loadingSize = size === 'small' ? '30' : 0
 
-    let loadingComponent: JSX.Element | null = null
-    if (loading) {
-      loadingComponent = (
-        <View className='at-button__icon'>
-          <AtLoading color={loadingColor} size={loadingSize} />
-        </View>
-      )
-      rootClassName.push('at-button--icon')
-    }
-
-    const webButton = (
-      <Button
-        className='at-button__wxbutton'
-        lang={lang}
-        formType={formType}
-      ></Button>
-    )
-
-    const button = (
-      <Button
-        className='at-button__wxbutton'
-        formType={formType}
-        openType={openType}
-        lang={lang}
-        sessionFrom={sessionFrom}
-        sendMessageTitle={sendMessageTitle}
-        sendMessagePath={sendMessagePath}
-        sendMessageImg={sendMessageImg}
-        showMessageCard={showMessageCard}
-        appParameter={appParameter}
-        onGetUserInfo={this.onGetUserInfo.bind(this)}
-        onGetPhoneNumber={this.onGetPhoneNumber.bind(this)}
-        onOpenSetting={this.onOpenSetting.bind(this)}
-        onError={this.onError.bind(this)}
-        onContact={this.onContact.bind(this)}
-      ></Button>
-    )
-
-    return (
-      <View
-        className={classNames(rootClassName, classObject, this.props.className)}
-        style={customStyle}
-        onClick={this.onClick.bind(this)}
-      >
-        {isWEB && !disabled && webButton}
-        {isWEAPP && !disabled && button}
-        {isALIPAY && !disabled && button}
-        {loadingComponent}
-        <View className='at-button__text'>{this.props.children}</View>
+  let loadingComponent: JSX.Element | null = null
+  if (loading) {
+    loadingComponent = (
+      <View className='at-button__icon'>
+        <AtLoading color={loadingColor} size={loadingSize} />
       </View>
     )
+    rootClassName.push('at-button--icon')
   }
-}
 
-AtButton.defaultProps = {
-  size: 'normal',
-  circle: false,
-  full: false,
-  loading: false,
-  disabled: false,
-  customStyle: {},
-  // Button props
-  lang: 'en',
-  sessionFrom: '',
-  sendMessageTitle: '',
-  sendMessagePath: '',
-  sendMessageImg: '',
-  showMessageCard: false,
-  appParameter: ''
+  const webButton = (
+    <Button
+      className='at-button__wxbutton'
+      lang={lang}
+      formType={formType}
+    ></Button>
+  )
+
+  const button = (
+    <Button
+      className='at-button__wxbutton'
+      formType={formType}
+      openType={openType}
+      lang={lang}
+      sessionFrom={sessionFrom}
+      sendMessageTitle={sendMessageTitle}
+      sendMessagePath={sendMessagePath}
+      sendMessageImg={sendMessageImg}
+      showMessageCard={showMessageCard}
+      appParameter={appParameter}
+      onGetUserInfo={handleGetUserInfo}
+      onGetPhoneNumber={handleGetPhoneNumber}
+      onOpenSetting={handleOpenSetting}
+      onError={handleError}
+      onContact={handleContact}
+    ></Button>
+  )
+
+  return (
+    <View
+      className={classNames(rootClassName, classObject, className)}
+      style={customStyle}
+      onClick={handleClick}
+    >
+      {isWEB && !disabled && webButton}
+      {isWEAPP && !disabled && button}
+      {isALIPAY && !disabled && button}
+      {loadingComponent}
+      <View className='at-button__text'>{children}</View>
+    </View>
+  )
 }
 
 AtButton.propTypes = {
@@ -200,3 +179,5 @@ AtButton.propTypes = {
   onError: PropTypes.func,
   onOpenSetting: PropTypes.func
 }
+
+export default AtButton

--- a/packages/taro-ui/src/components/calendar/body/index.tsx
+++ b/packages/taro-ui/src/components/calendar/body/index.tsx
@@ -1,6 +1,6 @@
 import classnames from 'classnames'
 import dayjs from 'dayjs'
-import React from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { Swiper, SwiperItem, View } from '@tarojs/components'
 import {
   BaseEventOrig,
@@ -10,7 +10,6 @@ import {
 import {
   AtCalendarBodyListGroup,
   AtCalendarBodyProps,
-  AtCalendarBodyState,
   Calendar
 } from '../../../../types/calendar'
 import { delayQuerySelector } from '../../../common/utils'
@@ -20,36 +19,34 @@ import AtCalendarDayList from '../ui/day-list/index'
 
 const ANIMTE_DURATION = 300
 
-const defaultProps: Partial<AtCalendarBodyProps> = {
-  marks: [],
-  selectedDate: {
+function AtCalendarBody({
+  marks = [],
+  selectedDate = {
     end: Date.now(),
     start: Date.now()
   },
-  format: 'YYYY-MM-DD',
-  generateDate: Date.now()
-}
+  format = 'YYYY-MM-DD',
+  generateDate = Date.now(),
+  validDates,
+  minDate,
+  maxDate,
+  selectedDates,
+  isSwiper,
+  isVertical,
+  onDayClick,
+  onLongClick,
+  onSwipeMonth
+}: AtCalendarBodyProps): JSX.Element {
+  const changeCountRef = useRef(0)
+  const currentSwiperIndexRef = useRef(1)
+  const startXRef = useRef(0)
+  const swipeStartPointRef = useRef(0)
+  const isPreMonthRef = useRef(false)
+  const maxWidthRef = useRef(0)
+  const isTouchingRef = useRef(false)
 
-export default class AtCalendarBody extends React.Component<
-  AtCalendarBodyProps,
-  Readonly<AtCalendarBodyState>
-> {
-  static defaultProps: Partial<AtCalendarBodyProps> = defaultProps
-
-  public constructor(props: AtCalendarBodyProps) {
-    super(props)
-    const {
-      validDates,
-      marks,
-      format,
-      minDate,
-      maxDate,
-      generateDate,
-      selectedDate,
-      selectedDates
-    } = props
-
-    this.generateFunc = generateCalendarGroup({
+  const generateFuncRef = useRef(
+    generateCalendarGroup({
       validDates,
       format,
       minDate,
@@ -57,167 +54,142 @@ export default class AtCalendarBody extends React.Component<
       marks,
       selectedDates
     })
-    const listGroup = this.getGroups(generateDate, selectedDate)
+  )
 
-    this.state = {
-      listGroup,
-      offsetSize: 0,
-      isAnimate: false
-    }
-  }
-
-  public componentDidMount(): void {
-    delayQuerySelector('.at-calendar-slider__main').then(res => {
-      this.maxWidth = res[0].width
-    })
-  }
-
-  public UNSAFE_componentWillReceiveProps(
-    nextProps: AtCalendarBodyProps
-  ): void {
-    const {
-      validDates,
-      marks,
-      format,
-      minDate,
-      maxDate,
-      generateDate,
-      selectedDate,
-      selectedDates
-    } = nextProps
-
-    this.generateFunc = generateCalendarGroup({
-      validDates,
-      format,
-      minDate,
-      maxDate,
-      marks,
-      selectedDates
-    })
-    const listGroup = this.getGroups(generateDate, selectedDate)
-
-    this.setState({
-      offsetSize: 0,
-      listGroup
-    })
-  }
-
-  private changeCount = 0
-  private currentSwiperIndex = 1
-  private startX = 0
-  private swipeStartPoint = 0
-  private isPreMonth = false
-  private maxWidth = 0
-  private isTouching = false
-
-  private generateFunc: (
-    generateDate: number,
-    selectedDate: Calendar.SelectedDate,
-    isShowStatus?: boolean
-  ) => Calendar.ListInfo<Calendar.Item>
-
-  private getGroups = (
-    generateDate: number,
-    selectedDate: Calendar.SelectedDate
+  const getGroups = (
+    genDate: number,
+    selDate: Calendar.SelectedDate
   ): AtCalendarBodyListGroup => {
-    const dayjsDate = dayjs(generateDate)
+    const dayjsDate = dayjs(genDate)
     const arr: AtCalendarBodyListGroup = []
-    const preList: Calendar.ListInfo<Calendar.Item> = this.generateFunc(
+    const preList: Calendar.ListInfo<Calendar.Item> = generateFuncRef.current(
       dayjsDate.subtract(1, 'month').valueOf(),
-      selectedDate
+      selDate
     )
 
-    const nowList: Calendar.ListInfo<Calendar.Item> = this.generateFunc(
-      generateDate,
-      selectedDate,
+    const nowList: Calendar.ListInfo<Calendar.Item> = generateFuncRef.current(
+      genDate,
+      selDate,
       true
     )
 
-    const nextList: Calendar.ListInfo<Calendar.Item> = this.generateFunc(
+    const nextList: Calendar.ListInfo<Calendar.Item> = generateFuncRef.current(
       dayjsDate.add(1, 'month').valueOf(),
-      selectedDate
+      selDate
     )
 
     const preListIndex =
-      this.currentSwiperIndex === 0 ? 2 : this.currentSwiperIndex - 1
+      currentSwiperIndexRef.current === 0
+        ? 2
+        : currentSwiperIndexRef.current - 1
     const nextListIndex =
-      this.currentSwiperIndex === 2 ? 0 : this.currentSwiperIndex + 1
+      currentSwiperIndexRef.current === 2
+        ? 0
+        : currentSwiperIndexRef.current + 1
 
     arr[preListIndex] = preList
     arr[nextListIndex] = nextList
-    arr[this.currentSwiperIndex] = nowList
+    arr[currentSwiperIndexRef.current] = nowList
 
     return arr
   }
 
-  private handleTouchStart = (e: ITouchEvent): void => {
-    if (!this.props.isSwiper) {
+  const [listGroup, setListGroup] = useState<AtCalendarBodyListGroup>(() =>
+    getGroups(generateDate, selectedDate)
+  )
+  const [offsetSize, setOffsetSize] = useState(0)
+  const [isAnimate, setIsAnimate] = useState(false)
+
+  useEffect(() => {
+    delayQuerySelector('.at-calendar-slider__main').then(res => {
+      maxWidthRef.current = res[0].width
+    })
+  }, [])
+
+  const isMountedRef = useRef(false)
+
+  useEffect(() => {
+    if (!isMountedRef.current) {
+      isMountedRef.current = true
       return
     }
-    this.isTouching = true
-    this.startX = e.touches[0].clientX
+
+    generateFuncRef.current = generateCalendarGroup({
+      validDates,
+      format,
+      minDate,
+      maxDate,
+      marks,
+      selectedDates
+    })
+    const nextListGroup = getGroups(generateDate, selectedDate)
+
+    setOffsetSize(0)
+    setListGroup(nextListGroup)
+  }, [
+    validDates,
+    marks,
+    format,
+    minDate,
+    maxDate,
+    generateDate,
+    selectedDate,
+    selectedDates
+  ])
+
+  const handleTouchStart = (e: ITouchEvent): void => {
+    if (!isSwiper) {
+      return
+    }
+    isTouchingRef.current = true
+    startXRef.current = e.touches[0].clientX
   }
 
-  private handleTouchMove = (e: ITouchEvent): void => {
-    if (!this.props.isSwiper) {
+  const handleTouchMove = (e: ITouchEvent): void => {
+    if (!isSwiper) {
       return
     }
-    if (!this.isTouching) return
+    if (!isTouchingRef.current) return
 
     const { clientX } = e.touches[0]
-    const offsetSize = clientX - this.startX
+    const nextOffsetSize = clientX - startXRef.current
 
-    this.setState({
-      offsetSize
+    setOffsetSize(nextOffsetSize)
+  }
+
+  const animateMoveSlide = (offset: number, callback?: () => void): void => {
+    setIsAnimate(true)
+    Promise.resolve().then(() => {
+      setOffsetSize(offset)
+      setTimeout(() => {
+        setIsAnimate(false)
+        callback?.()
+      }, ANIMTE_DURATION)
     })
   }
 
-  private animateMoveSlide = (offset: number, callback?: () => void): void => {
-    this.setState(
-      {
-        isAnimate: true
-      },
-      () => {
-        this.setState({
-          offsetSize: offset
-        })
-        setTimeout(() => {
-          this.setState(
-            {
-              isAnimate: false
-            },
-            () => {
-              callback?.()
-            }
-          )
-        }, ANIMTE_DURATION)
-      }
-    )
-  }
-
-  private handleTouchEnd = (): void => {
-    if (!this.props.isSwiper) {
+  const handleTouchEnd = (): void => {
+    if (!isSwiper) {
       return
     }
 
-    const { offsetSize } = this.state
-
-    this.isTouching = false
+    isTouchingRef.current = false
     const isRight = offsetSize > 0
 
-    const breakpoint = this.maxWidth / 2
+    const breakpoint = maxWidthRef.current / 2
     const absOffsetSize = Math.abs(offsetSize)
 
     if (absOffsetSize > breakpoint) {
-      const res = isRight ? this.maxWidth : -this.maxWidth
-      return this.animateMoveSlide(res, () => {
-        this.props.onSwipeMonth(isRight ? -1 : 1)
+      const res = isRight ? maxWidthRef.current : -maxWidthRef.current
+      animateMoveSlide(res, () => {
+        onSwipeMonth(isRight ? -1 : 1)
       })
+      return
     }
-    this.animateMoveSlide(0)
+    animateMoveSlide(0)
   }
 
-  private handleChange = (
+  const handleChange = (
     e: BaseEventOrig<{
       current: number
       source: string
@@ -226,109 +198,37 @@ export default class AtCalendarBody extends React.Component<
     const { current, source } = e.detail
 
     if (source === 'touch') {
-      this.currentSwiperIndex = current
-      this.changeCount += 1
+      currentSwiperIndexRef.current = current
+      changeCountRef.current += 1
     }
   }
 
-  private handleAnimateFinish = (): void => {
-    if (this.changeCount > 0) {
-      this.props.onSwipeMonth(
-        this.isPreMonth ? -this.changeCount : this.changeCount
+  const handleAnimateFinish = (): void => {
+    if (changeCountRef.current > 0) {
+      onSwipeMonth(
+        isPreMonthRef.current ? -changeCountRef.current : changeCountRef.current
       )
-      this.changeCount = 0
+      changeCountRef.current = 0
     }
   }
 
-  private handleSwipeTouchStart = (
+  const handleSwipeTouchStart = (
     e: ITouchEvent & { changedTouches: Array<ITouch> }
   ): void => {
     const { clientY, clientX } = e.changedTouches[0]
-    this.swipeStartPoint = this.props.isVertical ? clientY : clientX
+    swipeStartPointRef.current = isVertical ? clientY : clientX
   }
 
-  private handleSwipeTouchEnd = (
+  const handleSwipeTouchEnd = (
     e: ITouchEvent & { changedTouches: Array<ITouch> }
   ): void => {
     const { clientY, clientX } = e.changedTouches[0]
-    this.isPreMonth = this.props.isVertical
-      ? clientY - this.swipeStartPoint > 0
-      : clientX - this.swipeStartPoint > 0
+    isPreMonthRef.current = isVertical
+      ? clientY - swipeStartPointRef.current > 0
+      : clientX - swipeStartPointRef.current > 0
   }
 
-  public render(): JSX.Element {
-    const { isSwiper } = this.props
-    const { isAnimate, offsetSize, listGroup } = this.state
-
-    if (!isSwiper) {
-      return (
-        <View
-          className={classnames(
-            'main',
-            'at-calendar-slider__main',
-            `at-calendar-slider__main--${process.env.TARO_ENV}`
-          )}
-        >
-          <AtCalendarDayList />
-          <View className='main__body body'>
-            <View className='body__slider body__slider--now'>
-              <AtCalendarDateList
-                list={listGroup[1].list}
-                onClick={this.props.onDayClick}
-                onLongClick={this.props.onLongClick}
-              />
-            </View>
-          </View>
-        </View>
-      )
-    }
-
-    /* 需要 Taro 组件库维护 Swiper 使 小程序 和 H5 的表现保持一致  */
-    if (process.env.TARO_ENV === 'h5') {
-      return (
-        <View
-          className={classnames(
-            'main',
-            'at-calendar-slider__main',
-            `at-calendar-slider__main--${process.env.TARO_ENV}`
-          )}
-          onTouchEnd={this.handleTouchEnd}
-          onTouchMove={this.handleTouchMove}
-          onTouchStart={this.handleTouchStart}
-        >
-          <AtCalendarDayList />
-          <View
-            className={classnames('main__body  body', {
-              'main__body--slider': isSwiper,
-              'main__body--animate': isAnimate
-            })}
-            style={{
-              transform: isSwiper
-                ? `translateX(-100%) translate3d(${offsetSize},0,0)`
-                : '',
-              WebkitTransform: isSwiper
-                ? `translateX(-100%) translate3d(${offsetSize}px,0,0)`
-                : ''
-            }}
-          >
-            <View className='body__slider body__slider--pre'>
-              <AtCalendarDateList list={listGroup[0].list} />
-            </View>
-            <View className='body__slider body__slider--now'>
-              <AtCalendarDateList
-                list={listGroup[1].list}
-                onClick={this.props.onDayClick}
-                onLongClick={this.props.onLongClick}
-              />
-            </View>
-            <View className='body__slider body__slider--next'>
-              <AtCalendarDateList list={listGroup[2].list} />
-            </View>
-          </View>
-        </View>
-      )
-    }
-
+  if (!isSwiper) {
     return (
       <View
         className={classnames(
@@ -338,28 +238,97 @@ export default class AtCalendarBody extends React.Component<
         )}
       >
         <AtCalendarDayList />
-        <Swiper
-          circular
-          current={1}
-          skipHiddenItemLayout
-          className={classnames('main__body')}
-          onChange={this.handleChange}
-          vertical={this.props.isVertical}
-          onAnimationFinish={this.handleAnimateFinish}
-          onTouchEnd={this.handleSwipeTouchEnd}
-          onTouchStart={this.handleSwipeTouchStart}
-        >
-          {listGroup.map((item, key) => (
-            <SwiperItem key={key} itemId={key.toString()}>
-              <AtCalendarDateList
-                list={item.list}
-                onClick={this.props.onDayClick}
-                onLongClick={this.props.onLongClick}
-              />
-            </SwiperItem>
-          ))}
-        </Swiper>
+        <View className='main__body body'>
+          <View className='body__slider body__slider--now'>
+            <AtCalendarDateList
+              list={listGroup[1].list}
+              onClick={onDayClick}
+              onLongClick={onLongClick}
+            />
+          </View>
+        </View>
       </View>
     )
   }
+
+  /* 需要 Taro 组件库维护 Swiper 使 小程序 和 H5 的表现保持一致  */
+  if (process.env.TARO_ENV === 'h5') {
+    return (
+      <View
+        className={classnames(
+          'main',
+          'at-calendar-slider__main',
+          `at-calendar-slider__main--${process.env.TARO_ENV}`
+        )}
+        onTouchEnd={handleTouchEnd}
+        onTouchMove={handleTouchMove}
+        onTouchStart={handleTouchStart}
+      >
+        <AtCalendarDayList />
+        <View
+          className={classnames('main__body  body', {
+            'main__body--slider': isSwiper,
+            'main__body--animate': isAnimate
+          })}
+          style={{
+            transform: isSwiper
+              ? `translateX(-100%) translate3d(${offsetSize},0,0)`
+              : '',
+            WebkitTransform: isSwiper
+              ? `translateX(-100%) translate3d(${offsetSize}px,0,0)`
+              : ''
+          }}
+        >
+          <View className='body__slider body__slider--pre'>
+            <AtCalendarDateList list={listGroup[0].list} />
+          </View>
+          <View className='body__slider body__slider--now'>
+            <AtCalendarDateList
+              list={listGroup[1].list}
+              onClick={onDayClick}
+              onLongClick={onLongClick}
+            />
+          </View>
+          <View className='body__slider body__slider--next'>
+            <AtCalendarDateList list={listGroup[2].list} />
+          </View>
+        </View>
+      </View>
+    )
+  }
+
+  return (
+    <View
+      className={classnames(
+        'main',
+        'at-calendar-slider__main',
+        `at-calendar-slider__main--${process.env.TARO_ENV}`
+      )}
+    >
+      <AtCalendarDayList />
+      <Swiper
+        circular
+        current={1}
+        skipHiddenItemLayout
+        className={classnames('main__body')}
+        onChange={handleChange}
+        vertical={isVertical}
+        onAnimationFinish={handleAnimateFinish}
+        onTouchEnd={handleSwipeTouchEnd}
+        onTouchStart={handleSwipeTouchStart}
+      >
+        {listGroup.map((item, key) => (
+          <SwiperItem key={key} itemId={key.toString()}>
+            <AtCalendarDateList
+              list={item.list}
+              onClick={onDayClick}
+              onLongClick={onLongClick}
+            />
+          </SwiperItem>
+        ))}
+      </Swiper>
+    </View>
+  )
 }
+
+export default AtCalendarBody

--- a/packages/taro-ui/src/components/calendar/controller/index.tsx
+++ b/packages/taro-ui/src/components/calendar/controller/index.tsx
@@ -2,70 +2,71 @@ import classnames from 'classnames'
 import dayjs, { Dayjs } from 'dayjs'
 import React from 'react'
 import { Picker, Text, View } from '@tarojs/components'
-import {
-  AtCalendarControllerProps,
-  AtCalendarControllerState
-} from '../../../../types/calendar'
+import { AtCalendarControllerProps } from '../../../../types/calendar'
 
-export default class AtCalendarController extends React.Component<
-  AtCalendarControllerProps,
-  AtCalendarControllerState
-> {
-  public render(): JSX.Element {
-    const { generateDate, minDate, maxDate, monthFormat, hideArrow } =
-      this.props
+function AtCalendarController({
+  generateDate,
+  minDate,
+  maxDate,
+  monthFormat,
+  hideArrow,
+  onPreMonth,
+  onNextMonth,
+  onSelectDate
+}: AtCalendarControllerProps): JSX.Element {
+  const dayjsDate: Dayjs = dayjs(generateDate)
+  const dayjsMinDate: Dayjs | boolean = !!minDate && dayjs(minDate)
+  const dayjsMaxDate: Dayjs | boolean = !!maxDate && dayjs(maxDate)
 
-    const dayjsDate: Dayjs = dayjs(generateDate)
-    const dayjsMinDate: Dayjs | boolean = !!minDate && dayjs(minDate)
-    const dayjsMaxDate: Dayjs | boolean = !!maxDate && dayjs(maxDate)
+  const isMinMonth: boolean =
+    dayjsMinDate && dayjsMinDate.startOf('month').isSame(dayjsDate)
 
-    const isMinMonth: boolean =
-      dayjsMinDate && dayjsMinDate.startOf('month').isSame(dayjsDate)
+  const isMaxMonth: boolean =
+    dayjsMaxDate && dayjsMaxDate.startOf('month').isSame(dayjsDate)
 
-    const isMaxMonth: boolean =
-      dayjsMaxDate && dayjsMaxDate.startOf('month').isSame(dayjsDate)
+  const minDateValue: string = dayjsMinDate
+    ? dayjsMinDate.format('YYYY-MM')
+    : ''
+  const maxDateValue: string = dayjsMaxDate
+    ? dayjsMaxDate.format('YYYY-MM')
+    : ''
 
-    const minDateValue: string = dayjsMinDate
-      ? dayjsMinDate.format('YYYY-MM')
-      : ''
-    const maxDateValue: string = dayjsMaxDate
-      ? dayjsMaxDate.format('YYYY-MM')
-      : ''
-
-    return (
-      <View className='at-calendar__controller controller'>
-        {hideArrow ? null : (
-          <View
-            className={classnames('controller__arrow controller__arrow--left', {
-              'controller__arrow--disabled': isMinMonth
-            })}
-            onClick={this.props.onPreMonth.bind(this, isMinMonth)}
-          />
-        )}
-        <Picker
-          mode='date'
-          fields='month'
-          end={maxDateValue}
-          start={minDateValue}
-          onChange={this.props.onSelectDate}
-          value={dayjsDate.format('YYYY-MM')}
-        >
-          <Text className='controller__info'>
-            {dayjsDate.format(monthFormat)}
-          </Text>
-        </Picker>
-        {hideArrow ? null : (
-          <View
-            className={classnames(
-              'controller__arrow controller__arrow--right',
-              {
-                'controller__arrow--disabled': isMaxMonth
-              }
-            )}
-            onClick={this.props.onNextMonth.bind(this, isMaxMonth)}
-          />
-        )}
-      </View>
-    )
-  }
+  return (
+    <View className='at-calendar__controller controller'>
+      {hideArrow ? null : (
+        <View
+          className={classnames('controller__arrow controller__arrow--left', {
+            'controller__arrow--disabled': isMinMonth
+          })}
+          onClick={() =>
+            (onPreMonth as (monthDisabled?: boolean) => void)(isMinMonth)
+          }
+        />
+      )}
+      <Picker
+        mode='date'
+        fields='month'
+        end={maxDateValue}
+        start={minDateValue}
+        onChange={onSelectDate}
+        value={dayjsDate.format('YYYY-MM')}
+      >
+        <Text className='controller__info'>
+          {dayjsDate.format(monthFormat)}
+        </Text>
+      </Picker>
+      {hideArrow ? null : (
+        <View
+          className={classnames('controller__arrow controller__arrow--right', {
+            'controller__arrow--disabled': isMaxMonth
+          })}
+          onClick={() =>
+            (onNextMonth as (monthDisabled?: boolean) => void)(isMaxMonth)
+          }
+        />
+      )}
+    </View>
+  )
 }
+
+export default AtCalendarController

--- a/packages/taro-ui/src/components/calendar/index.tsx
+++ b/packages/taro-ui/src/components/calendar/index.tsx
@@ -1,10 +1,9 @@
 import classnames from 'classnames'
 import dayjs, { Dayjs } from 'dayjs'
-import React from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { View } from '@tarojs/components'
 import { BaseEventOrig } from '@tarojs/components/types/common'
 import {
-  AtCalendarDefaultProps,
   AtCalendarProps,
   AtCalendarPropsWithDefaults,
   AtCalendarState,
@@ -13,95 +12,29 @@ import {
 import AtCalendarBody from './body/index'
 import AtCalendarController from './controller/index'
 
-const defaultProps: AtCalendarDefaultProps = {
-  validDates: [],
-  marks: [],
-  isSwiper: true,
-  hideArrow: false,
-  isVertical: false,
-  selectedDates: [],
-  isMultiSelect: false,
-  format: 'YYYY-MM-DD',
-  currentDate: Date.now(),
-  monthFormat: 'YYYY年MM月'
-}
-
-export default class AtCalendar extends React.Component<
-  AtCalendarProps,
-  Readonly<AtCalendarState>
-> {
-  static defaultProps: AtCalendarDefaultProps = defaultProps
-
-  public constructor(props: AtCalendarProps) {
-    super(props)
-
-    const { currentDate, isMultiSelect } = props as AtCalendarPropsWithDefaults
-
-    this.state = this.getInitializeState(currentDate, isMultiSelect)
-  }
-
-  public UNSAFE_componentWillReceiveProps(nextProps: AtCalendarProps): void {
-    const { currentDate, isMultiSelect } = nextProps
-    if (!currentDate || currentDate === this.props.currentDate) return
-
-    if (isMultiSelect && this.props.isMultiSelect) {
-      const { start, end } = currentDate as Calendar.SelectedDate
-      const { start: preStart, end: preEnd } = this.props
-        .currentDate as Calendar.SelectedDate
-
-      if (start === preStart && preEnd === end) {
-        return
-      }
-    }
-
-    const stateValue: AtCalendarState = this.getInitializeState(
-      currentDate,
-      isMultiSelect
-    )
-
-    this.setState(stateValue)
-  }
-
-  private getSingleSelectdState = (value: Dayjs): Partial<AtCalendarState> => {
-    const { generateDate } = this.state
-
-    const stateValue: Partial<AtCalendarState> = {
-      selectedDate: this.getSelectedDate(value.valueOf())
-    }
-
-    const dayjsGenerateDate: Dayjs = value.startOf('month')
-    const generateDateValue: number = dayjsGenerateDate.valueOf()
-
-    if (generateDateValue !== generateDate) {
-      this.triggerChangeDate(dayjsGenerateDate)
-      stateValue.generateDate = generateDateValue
-    }
-
-    return stateValue
-  }
-
-  private getMultiSelectedState = (
-    value: Dayjs
-  ): Pick<AtCalendarState, 'selectedDate'> => {
-    const { selectedDate } = this.state
-    const { end, start } = selectedDate
-
-    const valueUnix: number = value.valueOf()
-    const state: Pick<AtCalendarState, 'selectedDate'> = {
-      selectedDate
-    }
-
-    if (end) {
-      state.selectedDate = this.getSelectedDate(valueUnix, 0)
-    } else {
-      state.selectedDate.end = Math.max(valueUnix, +start)
-      state.selectedDate.start = Math.min(valueUnix, +start)
-    }
-
-    return state
-  }
-
-  private getSelectedDate = (
+function AtCalendar(props: AtCalendarProps): JSX.Element {
+  const {
+    validDates = [],
+    marks = [],
+    isSwiper = true,
+    hideArrow = false,
+    isVertical = false,
+    selectedDates = [],
+    isMultiSelect = false,
+    format = 'YYYY-MM-DD',
+    currentDate = Date.now(),
+    monthFormat = 'YYYY年MM月',
+    minDate,
+    maxDate,
+    className,
+    onMonthChange,
+    onClickPreMonth,
+    onClickNextMonth,
+    onDayClick,
+    onSelectDate,
+    onDayLongClick
+  } = props as AtCalendarPropsWithDefaults
+  const getSelectedDate = (
     start: number,
     end?: number
   ): Calendar.SelectedDate => {
@@ -117,15 +50,15 @@ export default class AtCalendar extends React.Component<
     return stateValue
   }
 
-  private getInitializeState(
-    currentDate: Calendar.DateArg | Calendar.SelectedDate,
-    isMultiSelect?: boolean
-  ): AtCalendarState {
+  const getInitializeState = (
+    date: Calendar.DateArg | Calendar.SelectedDate,
+    multiSelect?: boolean
+  ): AtCalendarState => {
     let end: number
     let start: number
     let generateDateValue: number
 
-    if (!currentDate) {
+    if (!date) {
       const dayjsStart = dayjs()
       start = dayjsStart.startOf('day').valueOf()
       generateDateValue = dayjsStart.startOf('month').valueOf()
@@ -137,8 +70,8 @@ export default class AtCalendar extends React.Component<
       }
     }
 
-    if (isMultiSelect) {
-      const { start: cStart, end: cEnd } = currentDate as Calendar.SelectedDate
+    if (multiSelect) {
+      const { start: cStart, end: cEnd } = date as Calendar.SelectedDate
 
       const dayjsStart = dayjs(cStart)
 
@@ -147,7 +80,7 @@ export default class AtCalendar extends React.Component<
 
       end = cEnd ? dayjs(cEnd).startOf('day').valueOf() : start
     } else {
-      const dayjsStart = dayjs(currentDate as Calendar.DateArg)
+      const dayjsStart = dayjs(date as Calendar.DateArg)
 
       start = dayjsStart.startOf('day').valueOf()
       generateDateValue = dayjsStart.startOf('month').valueOf()
@@ -157,73 +90,160 @@ export default class AtCalendar extends React.Component<
 
     return {
       generateDate: generateDateValue,
-      selectedDate: this.getSelectedDate(start, end)
+      selectedDate: getSelectedDate(start, end)
     }
   }
 
-  private triggerChangeDate = (value: Dayjs): void => {
-    const { format } = this.props
+  const [generateDate, setGenerateDate] = useState<number>(
+    () => getInitializeState(currentDate, isMultiSelect).generateDate
+  )
+  const [selectedDate, setSelectedDate] = useState<Calendar.SelectedDate>(
+    () => getInitializeState(currentDate, isMultiSelect).selectedDate
+  )
 
-    if (typeof this.props.onMonthChange !== 'function') return
+  const prevCurrentDateRef = useRef(currentDate)
+  const prevIsMultiSelectRef = useRef(isMultiSelect)
 
-    this.props.onMonthChange(value.format(format))
+  useEffect(() => {
+    if (!currentDate || currentDate === prevCurrentDateRef.current) {
+      prevCurrentDateRef.current = currentDate
+      prevIsMultiSelectRef.current = isMultiSelect
+      return
+    }
+
+    if (isMultiSelect && prevIsMultiSelectRef.current) {
+      const { start, end } = currentDate as Calendar.SelectedDate
+      const { start: preStart, end: preEnd } =
+        prevCurrentDateRef.current as Calendar.SelectedDate
+
+      if (start === preStart && preEnd === end) {
+        prevCurrentDateRef.current = currentDate
+        prevIsMultiSelectRef.current = isMultiSelect
+        return
+      }
+    }
+
+    const stateValue = getInitializeState(currentDate, isMultiSelect)
+
+    setGenerateDate(stateValue.generateDate)
+    setSelectedDate(stateValue.selectedDate)
+    prevCurrentDateRef.current = currentDate
+    prevIsMultiSelectRef.current = isMultiSelect
+  }, [currentDate, isMultiSelect])
+
+  const triggerChangeDate = (value: Dayjs): void => {
+    if (typeof onMonthChange !== 'function') return
+
+    onMonthChange(value.format(format))
   }
 
-  private setMonth = (vectorCount: number): void => {
-    const { format } = this.props
-    const { generateDate } = this.state
-
+  const setMonth = (vectorCount: number): void => {
     const _generateDate: Dayjs = dayjs(generateDate).add(vectorCount, 'month')
-    this.setState({
-      generateDate: _generateDate.valueOf()
-    })
+    const nextGenerateDate = _generateDate.valueOf()
 
-    if (vectorCount && typeof this.props.onMonthChange === 'function') {
-      this.props.onMonthChange(_generateDate.format(format))
+    setGenerateDate(nextGenerateDate)
+
+    if (vectorCount && typeof onMonthChange === 'function') {
+      onMonthChange(_generateDate.format(format))
     }
   }
 
-  private handleClickPreMonth = (isMinMonth?: boolean): void => {
+  const handleClickPreMonth = (isMinMonth?: boolean): void => {
     if (isMinMonth === true) {
       return
     }
 
-    this.setMonth(-1)
+    setMonth(-1)
 
-    if (typeof this.props.onClickPreMonth === 'function') {
-      this.props.onClickPreMonth()
+    if (typeof onClickPreMonth === 'function') {
+      onClickPreMonth()
     }
   }
 
-  private handleClickNextMonth = (isMaxMonth?: boolean): void => {
+  const handleClickNextMonth = (isMaxMonth?: boolean): void => {
     if (isMaxMonth === true) {
       return
     }
 
-    this.setMonth(1)
+    setMonth(1)
 
-    if (typeof this.props.onClickNextMonth === 'function') {
-      this.props.onClickNextMonth()
+    if (typeof onClickNextMonth === 'function') {
+      onClickNextMonth()
     }
   }
 
-  // picker 选择时间改变时触发
-  private handleSelectDate = (e: BaseEventOrig<{ value: string }>): void => {
+  const handleSelectDate = (e: BaseEventOrig<{ value: string }>): void => {
     const { value } = e.detail
 
     const _generateDate: Dayjs = dayjs(value)
     const _generateDateValue: number = _generateDate.valueOf()
 
-    if (this.state.generateDate === _generateDateValue) return
+    if (generateDate === _generateDateValue) return
 
-    this.triggerChangeDate(_generateDate)
-    this.setState({
-      generateDate: _generateDateValue
-    })
+    triggerChangeDate(_generateDate)
+    setGenerateDate(_generateDateValue)
   }
 
-  private handleDayClick = (item: Calendar.Item): void => {
-    const { isMultiSelect } = this.props
+  const notifySelectedDate = (selectDate: Calendar.SelectedDate): void => {
+    if (typeof onSelectDate === 'function') {
+      const info: Calendar.SelectedDate = {
+        start: dayjs(selectDate.start).format(format)
+      }
+
+      if (selectDate.end) {
+        info.end = dayjs(selectDate.end).format(format)
+      }
+
+      onSelectDate({
+        value: info
+      })
+    }
+  }
+
+  const getSingleSelectdState = (
+    value: Dayjs,
+    currentGenerateDate: number
+  ): Partial<AtCalendarState> => {
+    const stateValue: Partial<AtCalendarState> = {
+      selectedDate: getSelectedDate(value.valueOf())
+    }
+
+    const dayjsGenerateDate: Dayjs = value.startOf('month')
+    const generateDateValue: number = dayjsGenerateDate.valueOf()
+
+    if (generateDateValue !== currentGenerateDate) {
+      triggerChangeDate(dayjsGenerateDate)
+      stateValue.generateDate = generateDateValue
+    }
+
+    return stateValue
+  }
+
+  const getMultiSelectedState = (
+    value: Dayjs,
+    currentSelectedDate: Calendar.SelectedDate
+  ): Pick<AtCalendarState, 'selectedDate'> => {
+    const { end, start } = currentSelectedDate
+
+    const valueUnix: number = value.valueOf()
+    const state: Pick<AtCalendarState, 'selectedDate'> = {
+      selectedDate: currentSelectedDate
+    }
+
+    if (end) {
+      state.selectedDate = getSelectedDate(valueUnix, 0)
+    } else {
+      state.selectedDate = {
+        ...currentSelectedDate,
+        end: Math.max(valueUnix, +start),
+        start: Math.min(valueUnix, +start)
+      }
+    }
+
+    return state
+  }
+
+  const handleDayClick = (item: Calendar.Item): void => {
     const { isDisabled, value } = item
 
     if (isDisabled) return
@@ -233,87 +253,59 @@ export default class AtCalendar extends React.Component<
     let stateValue: Partial<AtCalendarState> = {}
 
     if (isMultiSelect) {
-      stateValue = this.getMultiSelectedState(dayjsDate)
+      stateValue = getMultiSelectedState(dayjsDate, selectedDate)
     } else {
-      stateValue = this.getSingleSelectdState(dayjsDate)
+      stateValue = getSingleSelectdState(dayjsDate, generateDate)
     }
 
-    this.setState(stateValue as AtCalendarState, () => {
-      this.handleSelectedDate()
-    })
-
-    if (typeof this.props.onDayClick === 'function') {
-      this.props.onDayClick({ value: item.value })
+    if (stateValue.generateDate != null) {
+      setGenerateDate(stateValue.generateDate)
     }
-  }
+    if (stateValue.selectedDate != null) {
+      setSelectedDate(stateValue.selectedDate)
+      notifySelectedDate(stateValue.selectedDate)
+    }
 
-  private handleSelectedDate = (): void => {
-    const selectDate = this.state.selectedDate
-    if (typeof this.props.onSelectDate === 'function') {
-      const info: Calendar.SelectedDate = {
-        start: dayjs(selectDate.start).format(this.props.format)
-      }
-
-      if (selectDate.end) {
-        info.end = dayjs(selectDate.end).format(this.props.format)
-      }
-
-      this.props.onSelectDate({
-        value: info
-      })
+    if (typeof onDayClick === 'function') {
+      onDayClick({ value: item.value })
     }
   }
 
-  private handleDayLongClick = (item: Calendar.Item): void => {
-    if (typeof this.props.onDayLongClick === 'function') {
-      this.props.onDayLongClick({ value: item.value })
+  const handleDayLongClick = (item: Calendar.Item): void => {
+    if (typeof onDayLongClick === 'function') {
+      onDayLongClick({ value: item.value })
     }
   }
 
-  public render(): JSX.Element {
-    const { generateDate, selectedDate } = this.state
-    const {
-      validDates,
-      marks,
-      format,
-      minDate,
-      maxDate,
-      isSwiper,
-      className,
-      hideArrow,
-      isVertical,
-      monthFormat,
-      selectedDates
-    } = this.props as AtCalendarPropsWithDefaults
-
-    return (
-      <View className={classnames('at-calendar', className)}>
-        <AtCalendarController
-          minDate={minDate}
-          maxDate={maxDate}
-          hideArrow={hideArrow}
-          monthFormat={monthFormat}
-          generateDate={generateDate}
-          onPreMonth={this.handleClickPreMonth}
-          onNextMonth={this.handleClickNextMonth}
-          onSelectDate={this.handleSelectDate}
-        />
-        <AtCalendarBody
-          validDates={validDates}
-          marks={marks}
-          format={format}
-          minDate={minDate}
-          maxDate={maxDate}
-          isSwiper={isSwiper}
-          isVertical={isVertical}
-          selectedDate={selectedDate}
-          selectedDates={selectedDates}
-          generateDate={generateDate}
-          onDayClick={this.handleDayClick}
-          onSwipeMonth={this.setMonth}
-          onLongClick={this.handleDayLongClick}
-        />
-      </View>
-    )
-  }
+  return (
+    <View className={classnames('at-calendar', className)}>
+      <AtCalendarController
+        minDate={minDate}
+        maxDate={maxDate}
+        hideArrow={hideArrow}
+        monthFormat={monthFormat}
+        generateDate={generateDate}
+        onPreMonth={handleClickPreMonth}
+        onNextMonth={handleClickNextMonth}
+        onSelectDate={handleSelectDate}
+      />
+      <AtCalendarBody
+        validDates={validDates}
+        marks={marks}
+        format={format}
+        minDate={minDate}
+        maxDate={maxDate}
+        isSwiper={isSwiper}
+        isVertical={isVertical}
+        selectedDate={selectedDate}
+        selectedDates={selectedDates}
+        generateDate={generateDate}
+        onDayClick={handleDayClick}
+        onSwipeMonth={setMonth}
+        onLongClick={handleDayLongClick}
+      />
+    </View>
+  )
 }
+
+export default AtCalendar

--- a/packages/taro-ui/src/components/calendar/ui/date-list/index.tsx
+++ b/packages/taro-ui/src/components/calendar/ui/date-list/index.tsx
@@ -18,63 +18,62 @@ export interface Props {
   onLongClick?: (item: Calendar.Item) => void
 }
 
-export default class AtCalendarList extends React.Component<Props> {
-  private handleClick = (item: Calendar.Item): void => {
-    if (typeof this.props.onClick === 'function') {
-      this.props.onClick(item)
+function AtCalendarList({
+  list,
+  onClick,
+  onLongClick
+}: Props): JSX.Element | null {
+  const handleClick = (item: Calendar.Item): void => {
+    if (typeof onClick === 'function') {
+      onClick(item)
     }
   }
 
-  private handleLongClick = (item: Calendar.Item): void => {
-    if (typeof this.props.onLongClick === 'function') {
-      this.props.onLongClick(item)
+  const handleLongClick = (item: Calendar.Item): void => {
+    if (typeof onLongClick === 'function') {
+      onLongClick(item)
     }
   }
 
-  public render(): JSX.Element | null {
-    const { list } = this.props
-    if (!list || list.length === 0) return null
+  if (!list || list.length === 0) return null
 
-    return (
-      <View className='at-calendar__list flex'>
-        {list.map((item: Calendar.Item) => (
-          <View
-            key={`list-item-${item.value}`}
-            onClick={this.handleClick.bind(this, item)}
-            onLongPress={this.handleLongClick.bind(this, item)}
-            className={classnames(
-              'flex__item',
-              `flex__item--${MAP[item.type]}`,
-              {
-                'flex__item--today': item.isToday,
-                'flex__item--active': item.isActive,
-                'flex__item--selected': item.isSelected,
-                'flex__item--selected-head': item.isSelectedHead,
-                'flex__item--selected-tail': item.isSelectedTail,
-                'flex__item--blur':
-                  item.isDisabled ||
-                  item.type === constant.TYPE_PRE_MONTH ||
-                  item.type === constant.TYPE_NEXT_MONTH
-              }
-            )}
-          >
-            <View className='flex__item-container'>
-              <View className='container-text'>{item.text}</View>
-            </View>
-            <View className='flex__item-extra extra'>
-              {item.marks && item.marks.length > 0 ? (
-                <View className='extra-marks'>
-                  {item.marks.map((mark, key) => (
-                    <Text key={key} className='mark'>
-                      {mark.value}
-                    </Text>
-                  ))}
-                </View>
-              ) : null}
-            </View>
+  return (
+    <View className='at-calendar__list flex'>
+      {list.map((item: Calendar.Item) => (
+        <View
+          key={`list-item-${item.value}`}
+          onClick={() => handleClick(item)}
+          onLongPress={() => handleLongClick(item)}
+          className={classnames('flex__item', `flex__item--${MAP[item.type]}`, {
+            'flex__item--today': item.isToday,
+            'flex__item--active': item.isActive,
+            'flex__item--selected': item.isSelected,
+            'flex__item--selected-head': item.isSelectedHead,
+            'flex__item--selected-tail': item.isSelectedTail,
+            'flex__item--blur':
+              item.isDisabled ||
+              item.type === constant.TYPE_PRE_MONTH ||
+              item.type === constant.TYPE_NEXT_MONTH
+          })}
+        >
+          <View className='flex__item-container'>
+            <View className='container-text'>{item.text}</View>
           </View>
-        ))}
-      </View>
-    )
-  }
+          <View className='flex__item-extra extra'>
+            {item.marks && item.marks.length > 0 ? (
+              <View className='extra-marks'>
+                {item.marks.map((mark, key) => (
+                  <Text key={key} className='mark'>
+                    {mark.value}
+                  </Text>
+                ))}
+              </View>
+            ) : null}
+          </View>
+        </View>
+      ))}
+    </View>
+  )
 }
+
+export default AtCalendarList

--- a/packages/taro-ui/src/components/calendar/ui/day-list/index.tsx
+++ b/packages/taro-ui/src/components/calendar/ui/day-list/index.tsx
@@ -1,20 +1,20 @@
 import React from 'react'
 import { View } from '@tarojs/components'
 
-export default class AtCalendarHeader extends React.Component {
-  public render(): JSX.Element {
-    return (
-      <View className='at-calendar__header header'>
-        <View className='header__flex'>
-          <View className='header__flex-item'>日</View>
-          <View className='header__flex-item'>一</View>
-          <View className='header__flex-item'>二</View>
-          <View className='header__flex-item'>三</View>
-          <View className='header__flex-item'>四</View>
-          <View className='header__flex-item'>五</View>
-          <View className='header__flex-item'>六</View>
-        </View>
+function AtCalendarHeader(): JSX.Element {
+  return (
+    <View className='at-calendar__header header'>
+      <View className='header__flex'>
+        <View className='header__flex-item'>日</View>
+        <View className='header__flex-item'>一</View>
+        <View className='header__flex-item'>二</View>
+        <View className='header__flex-item'>三</View>
+        <View className='header__flex-item'>四</View>
+        <View className='header__flex-item'>五</View>
+        <View className='header__flex-item'>六</View>
       </View>
-    )
-  }
+    </View>
+  )
 }
+
+export default AtCalendarHeader

--- a/packages/taro-ui/src/components/card/index.tsx
+++ b/packages/taro-ui/src/components/card/index.tsx
@@ -1,80 +1,76 @@
 import classNames from 'classnames'
-import PropTypes, { InferProps } from 'prop-types'
+import PropTypes from 'prop-types'
 import React from 'react'
 import { Image, Text, View } from '@tarojs/components'
 import { AtCardProps } from '../../../types/card'
 
-export default class AtCard extends React.Component<AtCardProps> {
-  public static defaultProps: AtCardProps
-  public static propTypes: InferProps<AtCardProps>
-
-  private handleClick = (args: any): void => {
-    if (typeof this.props.onClick === 'function') {
-      this.props.onClick(args)
+export default function AtCard({
+  title = '',
+  note = '',
+  extra,
+  extraStyle = {},
+  thumb = '',
+  isFull = false,
+  icon,
+  renderIcon,
+  className,
+  children,
+  onClick
+}: AtCardProps): JSX.Element {
+  const handleClick = (args: any): void => {
+    if (typeof onClick === 'function') {
+      onClick(args)
     }
   }
 
-  public render(): JSX.Element {
-    const { title, note, extra, extraStyle, thumb, isFull, icon, renderIcon } =
-      this.props
+  const rootClass = classNames(
+    'at-card',
+    {
+      'at-card--full': isFull
+    },
+    className
+  )
+  const iconClass = classNames({
+    'at-icon': true,
+    [`at-icon-${icon && icon.value}`]: icon && icon.value,
+    'at-card__header-icon': true
+  })
 
-    const rootClass = classNames(
-      'at-card',
-      {
-        'at-card--full': isFull
-      },
-      this.props.className
-    )
-    const iconClass = classNames({
-      'at-icon': true,
-      [`at-icon-${icon && icon.value}`]: icon && icon.value,
-      'at-card__header-icon': true
-    })
+  const iconStyle = {
+    color: (icon && icon.color) || '',
+    fontSize: (icon && `${icon.size}px`) || ''
+  }
 
-    const iconStyle = {
-      color: (icon && icon.color) || '',
-      fontSize: (icon && `${icon.size}px`) || ''
-    }
+  return (
+    <View onClick={handleClick} className={rootClass}>
+      <View className='at-card__header'>
+        {thumb && (
+          <View className='at-card__header-thumb'>
+            <Image
+              className='at-card__header-thumb-info'
+              mode='scaleToFill'
+              src={thumb}
+            />
+          </View>
+        )}
+        {renderIcon || ''}
+        {!thumb && icon && icon.value && (
+          <Text className={iconClass} style={iconStyle}></Text>
+        )}
 
-    return (
-      <View onClick={this.handleClick} className={rootClass}>
-        <View className='at-card__header'>
-          {thumb && (
-            <View className='at-card__header-thumb'>
-              <Image
-                className='at-card__header-thumb-info'
-                mode='scaleToFill'
-                src={thumb}
-              />
-            </View>
-          )}
-          {renderIcon || ''}
-          {!thumb && icon && icon.value && (
-            <Text className={iconClass} style={iconStyle}></Text>
-          )}
-
-          <Text className='at-card__header-title'>{title}</Text>
-          {extra && (
-            <View style={{ ...extraStyle }} className='at-card__header-extra'>
-              {extra}
-            </View>
-          )}
-        </View>
-        <View className='at-card__content'>
-          <View className='at-card__content-info'>{this.props.children}</View>
-          {note && <View className='at-card__content-note'>{note}</View>}
-        </View>
+        <Text className='at-card__header-title'>{title}</Text>
+        {extra && (
+          <View style={{ ...extraStyle }} className='at-card__header-extra'>
+            {extra}
+          </View>
+        )}
       </View>
-    )
-  }
-}
-
-AtCard.defaultProps = {
-  note: '',
-  isFull: false,
-  thumb: '',
-  title: '',
-  extraStyle: {}
+      <View className='at-card__content'>
+        <View className='at-card__content-info'>{children}</View>
+        {note && <View className='at-card__content-note'>{note}</View>}
+      </View>
+    </View>
+  )
 }
 
 AtCard.propTypes = {

--- a/packages/taro-ui/src/components/checkbox/index.tsx
+++ b/packages/taro-ui/src/components/checkbox/index.tsx
@@ -1,15 +1,18 @@
 import classNames from 'classnames'
-import PropTypes, { InferProps } from 'prop-types'
+import PropTypes from 'prop-types'
 import React from 'react'
 import { Text, View } from '@tarojs/components'
 import { AtCheckboxProps } from '../../../types/checkbox'
+import { noop } from '../../common/utils'
 
-export default class AtCheckbox extends React.Component<AtCheckboxProps<any>> {
-  public static defaultProps: AtCheckboxProps<any>
-  public static propTypes: InferProps<AtCheckboxProps<any>>
-
-  private handleClick(idx: number): void {
-    const { selectedList, options } = this.props
+function AtCheckbox({
+  customStyle = '',
+  className = '',
+  options = [],
+  selectedList = [],
+  onChange = noop
+}: AtCheckboxProps<any>): JSX.Element {
+  const handleClick = (idx: number): void => {
     const option = options[idx]
     const { disabled, value } = option
     if (disabled) return
@@ -20,53 +23,40 @@ export default class AtCheckbox extends React.Component<AtCheckboxProps<any>> {
     } else {
       selectedSet.delete(value)
     }
-    this.props.onChange([...selectedSet])
+    onChange([...selectedSet])
   }
 
-  public render(): JSX.Element {
-    const { customStyle, className, options, selectedList } = this.props
+  const rootCls = classNames('at-checkbox', className)
 
-    const rootCls = classNames('at-checkbox', className)
+  return (
+    <View className={rootCls} style={customStyle}>
+      {options.map((option, idx) => {
+        const { value, disabled, label, desc } = option
+        const optionCls = classNames('at-checkbox__option', {
+          'at-checkbox__option--disabled': disabled,
+          'at-checkbox__option--selected': selectedList.includes(value)
+        })
 
-    return (
-      <View className={rootCls} style={customStyle}>
-        {options.map((option, idx) => {
-          const { value, disabled, label, desc } = option
-          const optionCls = classNames('at-checkbox__option', {
-            'at-checkbox__option--disabled': disabled,
-            'at-checkbox__option--selected': selectedList.includes(value)
-          })
-
-          return (
-            <View
-              className={optionCls}
-              key={value}
-              onClick={this.handleClick.bind(this, idx)}
-            >
-              <View className='at-checkbox__option-wrap'>
-                <View className='at-checkbox__option-cnt'>
-                  <View className='at-checkbox__icon-cnt'>
-                    <Text className='at-icon at-icon-check'></Text>
-                  </View>
-                  <View className='at-checkbox__title'>{label}</View>
+        return (
+          <View
+            className={optionCls}
+            key={value}
+            onClick={() => handleClick(idx)}
+          >
+            <View className='at-checkbox__option-wrap'>
+              <View className='at-checkbox__option-cnt'>
+                <View className='at-checkbox__icon-cnt'>
+                  <Text className='at-icon at-icon-check'></Text>
                 </View>
-                {desc && <View className='at-checkbox__desc'>{desc}</View>}
+                <View className='at-checkbox__title'>{label}</View>
               </View>
+              {desc && <View className='at-checkbox__desc'>{desc}</View>}
             </View>
-          )
-        })}
-      </View>
-    )
-  }
-}
-
-AtCheckbox.defaultProps = {
-  customStyle: '',
-  className: '',
-  options: [],
-  selectedList: [],
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  onChange: (): void => {}
+          </View>
+        )
+      })}
+    </View>
+  )
 }
 
 AtCheckbox.propTypes = {
@@ -76,3 +66,5 @@ AtCheckbox.propTypes = {
   selectedList: PropTypes.array,
   onChange: PropTypes.func
 }
+
+export default AtCheckbox

--- a/packages/taro-ui/src/components/countdown/index.tsx
+++ b/packages/taro-ui/src/components/countdown/index.tsx
@@ -1,8 +1,9 @@
 import classNames from 'classnames'
-import PropTypes, { InferProps } from 'prop-types'
-import React from 'react'
+import PropTypes from 'prop-types'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { View } from '@tarojs/components'
-import { AtCountDownProps, AtCountdownState } from '../../../types/countdown'
+import { useDidHide, useDidShow } from '@tarojs/taro'
+import { AtCountDownProps } from '../../../types/countdown'
 import AtCountdownItem from './item'
 
 type TimeObject = {
@@ -26,169 +27,205 @@ const defaultFormat = {
   seconds: '秒'
 }
 
-export default class AtCountdown extends React.Component<
-  AtCountDownProps,
-  AtCountdownState
-> {
-  public static defaultProps: AtCountDownProps
-  public static propTypes: InferProps<AtCountDownProps>
+function AtCountdown({
+  customStyle = '',
+  className = '',
+  format = defaultFormat,
+  isCard = false,
+  isShowDay = false,
+  isShowHour = true,
+  isShowMinute = true,
+  day = 0,
+  hours = 0,
+  minutes = 0,
+  seconds = 0,
+  onTimeUp
+}: AtCountDownProps): JSX.Element {
+  const propsRef = useRef<AtCountDownProps>({
+    customStyle,
+    className,
+    format,
+    isCard,
+    isShowDay,
+    isShowHour,
+    isShowMinute,
+    day,
+    hours,
+    minutes,
+    seconds,
+    onTimeUp
+  })
+  const isMountedRef = useRef(false)
+  const secondsRef = useRef(toSeconds(day, hours, minutes, seconds))
+  const timerRef = useRef<NodeJS.Timeout | number>()
 
-  private seconds: number
-  private timer: NodeJS.Timeout | number | undefined
+  const calculateTime = useCallback((): TimeObject => {
+    let [calcDay, calcHours, calcMinutes, calcSeconds] = [0, 0, 0, 0]
 
-  public constructor(props: AtCountDownProps) {
-    super(props)
-    const { day = 0, hours = 0, minutes = 0, seconds = 0 } = this.props
-    this.seconds = toSeconds(day, hours, minutes, seconds)
-    const {
-      day: _day,
-      hours: _hours,
-      minutes: _minutes,
-      seconds: _seconds
-    } = this.calculateTime()
-
-    this.state = {
-      _day,
-      _hours,
-      _minutes,
-      _seconds
-    }
-  }
-
-  private setTimer(): void {
-    if (!this.timer) this.countdonwn()
-  }
-
-  private clearTimer(): void {
-    if (this.timer) {
-      clearTimeout(this.timer as number)
-      this.timer = 0
-    }
-  }
-
-  private calculateTime(): TimeObject {
-    let [day, hours, minutes, seconds] = [0, 0, 0, 0]
-
-    if (this.seconds > 0) {
-      day = this.props.isShowDay ? Math.floor(this.seconds / (60 * 60 * 24)) : 0
-      hours = this.props.isShowHour
-        ? Math.floor(this.seconds / (60 * 60)) - day * 24
+    if (secondsRef.current > 0) {
+      calcDay = isShowDay ? Math.floor(secondsRef.current / (60 * 60 * 24)) : 0
+      calcHours = isShowHour
+        ? Math.floor(secondsRef.current / (60 * 60)) - calcDay * 24
         : 0
-      minutes = this.props.isShowMinute
-        ? Math.floor(this.seconds / 60) - day * 24 * 60 - hours * 60
+      calcMinutes = isShowMinute
+        ? Math.floor(secondsRef.current / 60) -
+          calcDay * 24 * 60 -
+          calcHours * 60
         : 0
-      seconds =
-        Math.floor(this.seconds) -
-        day * 24 * 60 * 60 -
-        hours * 60 * 60 -
-        minutes * 60
+      calcSeconds =
+        Math.floor(secondsRef.current) -
+        calcDay * 24 * 60 * 60 -
+        calcHours * 60 * 60 -
+        calcMinutes * 60
     }
     return {
-      day,
-      hours,
-      minutes,
-      seconds
+      day: calcDay,
+      hours: calcHours,
+      minutes: calcMinutes,
+      seconds: calcSeconds
     }
-  }
+  }, [isShowDay, isShowHour, isShowMinute])
 
-  private countdonwn(): void {
-    const { day, hours, minutes, seconds } = this.calculateTime()
+  const initialTime = calculateTime()
+  const [_day, setDay] = useState(initialTime.day)
+  const [_hours, setHours] = useState(initialTime.hours)
+  const [_minutes, setMinutes] = useState(initialTime.minutes)
+  const [_seconds, setSeconds] = useState(initialTime.seconds)
 
-    this.setState({
-      _day: day,
-      _hours: hours,
-      _minutes: minutes,
-      _seconds: seconds
-    })
-    this.seconds--
+  const clearTimer = useCallback((): void => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current as number)
+      timerRef.current = 0
+    }
+  }, [])
 
-    if (this.seconds < 0) {
-      this.clearTimer()
-      this.props.onTimeUp && this.props.onTimeUp()
+  const countdown = useCallback((): void => {
+    const {
+      day: calcDay,
+      hours: calcHours,
+      minutes: calcMinutes,
+      seconds: calcSeconds
+    } = calculateTime()
+
+    setDay(calcDay)
+    setHours(calcHours)
+    setMinutes(calcMinutes)
+    setSeconds(calcSeconds)
+    secondsRef.current--
+
+    if (secondsRef.current < 0) {
+      clearTimer()
+      onTimeUp && onTimeUp()
       return
     }
 
-    this.timer = setTimeout(() => {
-      this.countdonwn()
+    timerRef.current = setTimeout(() => {
+      countdown()
     }, 1000)
-  }
+  }, [calculateTime, clearTimer, onTimeUp])
 
-  public UNSAFE_componentWillReceiveProps(nextProps: AtCountDownProps): void {
-    if (JSON.stringify(this.props) === JSON.stringify(nextProps)) return
+  const setTimer = useCallback((): void => {
+    if (!timerRef.current) countdown()
+  }, [countdown])
 
-    const { day = 0, hours = 0, minutes = 0, seconds = 0 } = nextProps
-    this.seconds = toSeconds(day, hours, minutes, seconds)
-    this.clearTimer()
-    this.setTimer()
-  }
-
-  public componentDidMount(): void {
-    this.setTimer()
-  }
-
-  public componentWillUnmount(): void {
-    this.clearTimer()
-  }
-
-  public componentDidHide(): void {
-    this.clearTimer()
-  }
-
-  public componentDidShow(): void {
-    this.setTimer()
-  }
-
-  public render(): JSX.Element {
-    const {
-      className,
+  useEffect(() => {
+    propsRef.current = {
       customStyle,
-      format = defaultFormat,
+      className,
+      format,
       isCard,
       isShowDay,
       isShowHour,
-      isShowMinute
-    } = this.props
+      isShowMinute,
+      day,
+      hours,
+      minutes,
+      seconds,
+      onTimeUp
+    }
+  })
 
-    const { _day, _hours, _minutes, _seconds } = this.state
+  useEffect(() => {
+    const nextProps = {
+      customStyle,
+      className,
+      format,
+      isCard,
+      isShowDay,
+      isShowHour,
+      isShowMinute,
+      day,
+      hours,
+      minutes,
+      seconds,
+      onTimeUp
+    }
+    if (!isMountedRef.current) {
+      isMountedRef.current = true
+      propsRef.current = nextProps
+      return
+    }
+    if (JSON.stringify(propsRef.current) === JSON.stringify(nextProps)) return
 
-    return (
-      <View
-        className={classNames(
-          {
-            'at-countdown': true,
-            'at-countdown--card': isCard
-          },
-          className
-        )}
-        style={customStyle}
-      >
-        {isShowDay && (
-          <AtCountdownItem num={_day} separator={format?.day || '天'} />
-        )}
-        {isShowHour && (
-          <AtCountdownItem num={_hours} separator={format?.hours || ''} />
-        )}
-        {isShowMinute && (
-          <AtCountdownItem num={_minutes} separator={format?.minutes || ''} />
-        )}
-        <AtCountdownItem num={_seconds} separator={format?.seconds || ''} />
-      </View>
-    )
-  }
-}
+    propsRef.current = nextProps
+    secondsRef.current = toSeconds(day, hours, minutes, seconds)
+    clearTimer()
+    setTimer()
+  }, [
+    customStyle,
+    className,
+    format,
+    isCard,
+    isShowDay,
+    isShowHour,
+    isShowMinute,
+    day,
+    hours,
+    minutes,
+    seconds,
+    onTimeUp,
+    clearTimer,
+    setTimer
+  ])
 
-AtCountdown.defaultProps = {
-  customStyle: '',
-  className: '',
-  isCard: false,
-  isShowDay: false,
-  isShowHour: true,
-  isShowMinute: true,
-  format: defaultFormat,
-  day: 0,
-  hours: 0,
-  minutes: 0,
-  seconds: 0
+  useEffect(() => {
+    setTimer()
+    return () => {
+      clearTimer()
+    }
+  }, [setTimer, clearTimer])
+
+  useDidHide(() => {
+    clearTimer()
+  })
+
+  useDidShow(() => {
+    setTimer()
+  })
+
+  return (
+    <View
+      className={classNames(
+        {
+          'at-countdown': true,
+          'at-countdown--card': isCard
+        },
+        className
+      )}
+      style={customStyle}
+    >
+      {isShowDay && (
+        <AtCountdownItem num={_day} separator={format?.day || '天'} />
+      )}
+      {isShowHour && (
+        <AtCountdownItem num={_hours} separator={format?.hours || ''} />
+      )}
+      {isShowMinute && (
+        <AtCountdownItem num={_minutes} separator={format?.minutes || ''} />
+      )}
+      <AtCountdownItem num={_seconds} separator={format?.seconds || ''} />
+    </View>
+  )
 }
 
 AtCountdown.propTypes = {
@@ -205,3 +242,5 @@ AtCountdown.propTypes = {
   seconds: PropTypes.number,
   onTimeUp: PropTypes.func
 }
+
+export default AtCountdown

--- a/packages/taro-ui/src/components/countdown/item/index.tsx
+++ b/packages/taro-ui/src/components/countdown/item/index.tsx
@@ -1,36 +1,29 @@
-import PropTypes, { InferProps } from 'prop-types'
+import PropTypes from 'prop-types'
 import React from 'react'
 import { Text, View } from '@tarojs/components'
 import { AtCountdownItemProps } from '../../../../types/countdown'
 
-export default class AtCountdownItem extends React.Component<AtCountdownItemProps> {
-  public static defaultProps: AtCountdownItemProps
-  public static propTypes: InferProps<AtCountdownItemProps>
-
-  private formatNum(num: number): string {
-    return num <= 9 ? `0${num}` : `${num}`
-  }
-
-  public render(): JSX.Element {
-    const { num, separator } = this.props
-
-    return (
-      <View className='at-countdown__item'>
-        <View className='at-countdown__time-box'>
-          <Text className='at-countdown__time'>{this.formatNum(num)}</Text>
-        </View>
-        <Text className='at-countdown__separator'>{separator}</Text>
-      </View>
-    )
-  }
+function formatNum(num: number): string {
+  return num <= 9 ? `0${num}` : `${num}`
 }
 
-AtCountdownItem.defaultProps = {
-  num: 0,
-  separator: ':'
+function AtCountdownItem({
+  num = 0,
+  separator = ':'
+}: AtCountdownItemProps): JSX.Element {
+  return (
+    <View className='at-countdown__item'>
+      <View className='at-countdown__time-box'>
+        <Text className='at-countdown__time'>{formatNum(num)}</Text>
+      </View>
+      <Text className='at-countdown__separator'>{separator}</Text>
+    </View>
+  )
 }
 
 AtCountdownItem.propTypes = {
   num: PropTypes.number.isRequired,
   separator: PropTypes.string
 }
+
+export default AtCountdownItem

--- a/packages/taro-ui/src/components/curtain/index.tsx
+++ b/packages/taro-ui/src/components/curtain/index.tsx
@@ -1,65 +1,54 @@
 import classNames from 'classnames'
-import PropTypes, { InferProps } from 'prop-types'
+import PropTypes from 'prop-types'
 import React from 'react'
 import { View } from '@tarojs/components'
 import { CommonEvent } from '@tarojs/components/types/common'
 import { AtCurtainProps } from '../../../types/curtain'
+import { noop } from '../../common/utils'
 
-export default class AtCurtain extends React.Component<AtCurtainProps> {
-  public static defaultProps: AtCurtainProps
-  public static propTypes: InferProps<AtCurtainProps>
-
-  private onClose(e: CommonEvent): void {
+function AtCurtain({
+  className = '',
+  customStyle = '',
+  isOpened = false,
+  closeBtnPosition = 'bottom',
+  onClose = noop,
+  children
+}: AtCurtainProps): JSX.Element {
+  const handleClose = (e: CommonEvent): void => {
     e.stopPropagation()
-    this.props.onClose(e)
+    onClose(e)
   }
 
-  private _stopPropagation(e: CommonEvent): void {
+  const stopPropagation = (e: CommonEvent): void => {
     e.stopPropagation()
   }
 
-  public render(): JSX.Element {
-    const { className, customStyle, isOpened, closeBtnPosition } = this.props
+  const curtainClass = classNames(
+    {
+      'at-curtain': true,
+      'at-curtain--closed': !isOpened
+    },
+    className
+  )
+  const btnCloseClass = classNames({
+    'at-curtain__btn-close': true,
+    [`at-curtain__btn-close--${closeBtnPosition}`]: closeBtnPosition
+  })
 
-    const curtainClass = classNames(
-      {
-        'at-curtain': true,
-        'at-curtain--closed': !isOpened
-      },
-      className
-    )
-    const btnCloseClass = classNames({
-      'at-curtain__btn-close': true,
-      [`at-curtain__btn-close--${closeBtnPosition}`]: closeBtnPosition
-    })
-
-    return (
-      <View
-        className={curtainClass}
-        style={customStyle}
-        onClick={this._stopPropagation}
-      >
-        <View className='at-curtain__container'>
-          <View className='at-curtain__body'>
-            {this.props.children}
-            <View
-              className={btnCloseClass}
-              onClick={this.onClose.bind(this)}
-            ></View>
-          </View>
+  return (
+    <View
+      className={curtainClass}
+      style={customStyle}
+      onClick={stopPropagation}
+    >
+      <View className='at-curtain__container'>
+        <View className='at-curtain__body'>
+          {children}
+          <View className={btnCloseClass} onClick={handleClose}></View>
         </View>
       </View>
-    )
-  }
-}
-
-AtCurtain.defaultProps = {
-  customStyle: '',
-  className: '',
-  isOpened: false,
-  closeBtnPosition: 'bottom',
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  onClose: (): void => {}
+    </View>
+  )
 }
 
 AtCurtain.propTypes = {
@@ -69,3 +58,5 @@ AtCurtain.propTypes = {
   closeBtnPosition: PropTypes.string,
   onClose: PropTypes.func
 }
+
+export default AtCurtain

--- a/packages/taro-ui/src/components/divider/index.tsx
+++ b/packages/taro-ui/src/components/divider/index.tsx
@@ -1,58 +1,44 @@
 import classNames from 'classnames'
-import PropTypes, { InferProps } from 'prop-types'
+import PropTypes from 'prop-types'
 import React from 'react'
 import { View } from '@tarojs/components'
 import { AtDividerProps } from '../../../types/divider'
 import { mergeStyle, pxTransform } from '../../common/utils'
 
-export default class AtDivider extends React.Component<AtDividerProps> {
-  public static defaultProps: AtDividerProps
-  public static propTypes: InferProps<AtDividerProps>
-
-  public render(): JSX.Element {
-    const {
-      className,
-      customStyle,
-      content,
-      height,
-      fontColor,
-      fontSize,
-      lineColor
-    } = this.props
-
-    const rootStyle = {
-      height: height ? `${pxTransform(Number(height))}` : ''
-    }
-
-    const fontStyle = {
-      color: fontColor,
-      fontSize: fontSize ? `${pxTransform(Number(fontSize))}` : ''
-    }
-
-    const lineStyle: React.CSSProperties = {
-      backgroundColor: lineColor
-    }
-
-    return (
-      <View
-        className={classNames('at-divider', className)}
-        style={mergeStyle(rootStyle, customStyle as object)}
-      >
-        <View className='at-divider__content' style={fontStyle}>
-          {content === '' ? this.props.children : content}
-        </View>
-        <View className='at-divider__line' style={lineStyle}></View>
-      </View>
-    )
+export default function AtDivider({
+  className,
+  customStyle,
+  content = '',
+  height = 0,
+  fontColor = '',
+  fontSize = 0,
+  lineColor = '',
+  children
+}: AtDividerProps): JSX.Element {
+  const rootStyle = {
+    height: height ? `${pxTransform(Number(height))}` : ''
   }
-}
 
-AtDivider.defaultProps = {
-  content: '',
-  height: 0,
-  fontColor: '',
-  fontSize: 0,
-  lineColor: ''
+  const fontStyle = {
+    color: fontColor,
+    fontSize: fontSize ? `${pxTransform(Number(fontSize))}` : ''
+  }
+
+  const lineStyle: React.CSSProperties = {
+    backgroundColor: lineColor
+  }
+
+  return (
+    <View
+      className={classNames('at-divider', className)}
+      style={mergeStyle(rootStyle, customStyle as object)}
+    >
+      <View className='at-divider__content' style={fontStyle}>
+        {content === '' ? children : content}
+      </View>
+      <View className='at-divider__line' style={lineStyle}></View>
+    </View>
+  )
 }
 
 AtDivider.propTypes = {

--- a/packages/taro-ui/src/components/drawer/index.tsx
+++ b/packages/taro-ui/src/components/drawer/index.tsx
@@ -1,133 +1,137 @@
 import classNames from 'classnames'
-import PropTypes, { InferProps } from 'prop-types'
-import React from 'react'
+import PropTypes from 'prop-types'
+import React, { useEffect, useRef, useState } from 'react'
 import { View } from '@tarojs/components'
-import { AtDrawerProps, AtDrawerState } from '../../../types/drawer'
+import { AtDrawerProps } from '../../../types/drawer'
 import AtList from '../list/index'
 import AtListItem from '../list/item/index'
 
-export default class AtDrawer extends React.Component<
-  AtDrawerProps,
-  AtDrawerState
-> {
-  public static defaultProps: AtDrawerProps
-  public static propTypes: InferProps<AtDrawerProps>
+function AtDrawer({
+  show = false,
+  mask = true,
+  width = '',
+  right = false,
+  items = [],
+  className,
+  children,
+  onItemClick,
+  onClose
+}: AtDrawerProps): JSX.Element {
+  const [animShow, setAnimShow] = useState(false)
+  const [_show, setShow] = useState(show)
+  const showStateRef = useRef(show)
+  const isMountRef = useRef(true)
+  const hideTimerRef = useRef<ReturnType<typeof setTimeout>>()
+  const showTimerRef = useRef<ReturnType<typeof setTimeout>>()
 
-  public constructor(props: AtDrawerProps) {
-    super(props)
-    this.state = {
-      animShow: false,
-      _show: props.show
+  const onHide = (): void => {
+    setShow(false)
+    onClose && onClose()
+  }
+
+  const animHide = (): void => {
+    setAnimShow(false)
+    if (hideTimerRef.current) {
+      clearTimeout(hideTimerRef.current)
     }
-  }
-
-  public componentDidMount(): void {
-    const { _show } = this.state
-    if (_show) this.animShow()
-  }
-
-  private onItemClick(index: number): void {
-    this.props.onItemClick && this.props.onItemClick(index)
-    this.animHide()
-  }
-
-  private onHide(): void {
-    this.setState({ _show: false }, () => {
-      this.props.onClose && this.props.onClose()
-    })
-  }
-
-  private animHide(): void {
-    this.setState({
-      animShow: false
-    })
-    setTimeout(() => {
-      this.onHide()
+    hideTimerRef.current = setTimeout(() => {
+      onHide()
     }, 300)
   }
 
-  private animShow(): void {
-    this.setState({ _show: true })
-    setTimeout(() => {
-      this.setState({
-        animShow: true
-      })
+  const runAnimShow = (): void => {
+    setShow(true)
+    if (showTimerRef.current) {
+      clearTimeout(showTimerRef.current)
+    }
+    showTimerRef.current = setTimeout(() => {
+      setAnimShow(true)
     }, 200)
   }
 
-  private onMaskClick(): void {
-    this.animHide()
+  useEffect(() => {
+    showStateRef.current = _show
+  }, [_show])
+
+  useEffect(() => {
+    if (isMountRef.current) {
+      isMountRef.current = false
+      if (show) {
+        runAnimShow()
+      }
+      return
+    }
+    if (show !== showStateRef.current) {
+      show ? runAnimShow() : animHide()
+    }
+  }, [show])
+
+  useEffect(() => {
+    return () => {
+      if (hideTimerRef.current) {
+        clearTimeout(hideTimerRef.current)
+      }
+      if (showTimerRef.current) {
+        clearTimeout(showTimerRef.current)
+      }
+    }
+  }, [])
+
+  const onItemClickHandler = (index: number): void => {
+    onItemClick && onItemClick(index)
+    animHide()
   }
 
-  public UNSAFE_componentWillReceiveProps(nextProps: AtDrawerProps): void {
-    const { show } = nextProps
-    if (show !== this.state._show) {
-      show ? this.animShow() : this.animHide()
-    }
+  const onMaskClick = (): void => {
+    animHide()
   }
 
-  public render(): JSX.Element {
-    const { mask, width, right, items } = this.props
-    const { animShow, _show } = this.state
-    const rootClassName = ['at-drawer']
+  const maskStyle = {
+    display: mask ? 'block' : 'none',
+    opacity: animShow ? 1 : 0
+  }
+  const listStyle = {
+    width,
+    transition: animShow
+      ? 'all 225ms cubic-bezier(0, 0, 0.2, 1)'
+      : 'all 195ms cubic-bezier(0.4, 0, 0.6, 1)'
+  }
 
-    const maskStyle = {
-      display: mask ? 'block' : 'none',
-      opacity: animShow ? 1 : 0
-    }
-    const listStyle = {
-      width,
-      transition: animShow
-        ? 'all 225ms cubic-bezier(0, 0, 0.2, 1)'
-        : 'all 195ms cubic-bezier(0.4, 0, 0.6, 1)'
-    }
+  const classObject = {
+    'at-drawer--show': animShow,
+    'at-drawer--right': right,
+    'at-drawer--left': !right
+  }
 
-    const classObject = {
-      'at-drawer--show': animShow,
-      'at-drawer--right': right,
-      'at-drawer--left': !right
-    }
-
-    return _show ? (
+  return _show ? (
+    <View className={classNames(['at-drawer'], classObject, className)}>
       <View
-        className={classNames(rootClassName, classObject, this.props.className)}
-      >
-        <View
-          className='at-drawer__mask'
-          style={maskStyle}
-          onClick={this.onMaskClick.bind(this)}
-        ></View>
+        className='at-drawer__mask'
+        style={maskStyle}
+        onClick={onMaskClick}
+      ></View>
 
-        <View className='at-drawer__content' style={listStyle}>
-          {!!items && items.length ? (
-            <AtList>
-              {items.map((name, index) => (
-                <AtListItem
-                  key={`${name}-${index}`}
-                  data-index={index}
-                  onClick={this.onItemClick.bind(this, index)}
-                  title={name}
-                  arrow='right'
-                ></AtListItem>
-              ))}
-            </AtList>
-          ) : (
-            this.props.children
-          )}
-        </View>
+      <View className='at-drawer__content' style={listStyle}>
+        {!!items && items.length ? (
+          <AtList>
+            {items.map((name, index) => (
+              <AtListItem
+                key={`${name}-${index}`}
+                data-index={index}
+                onClick={() => onItemClickHandler(index)}
+                title={name}
+                arrow='right'
+              ></AtListItem>
+            ))}
+          </AtList>
+        ) : (
+          children
+        )}
       </View>
-    ) : (
-      <View></View>
-    )
-  }
-}
-
-AtDrawer.defaultProps = {
-  show: false,
-  mask: true,
-  width: '',
-  right: false,
-  items: []
+    </View>
+  ) : (
+    <View></View>
+  )
 }
 
 AtDrawer.propTypes = {
@@ -138,3 +142,5 @@ AtDrawer.propTypes = {
   onItemClick: PropTypes.func,
   onClose: PropTypes.func
 }
+
+export default AtDrawer

--- a/packages/taro-ui/src/components/fab/index.tsx
+++ b/packages/taro-ui/src/components/fab/index.tsx
@@ -1,33 +1,31 @@
 import classNames from 'classnames'
-import PropTypes, { InferProps } from 'prop-types'
+import PropTypes from 'prop-types'
 import React from 'react'
 import { View } from '@tarojs/components'
 import { CommonEvent } from '@tarojs/components/types/common'
 import { AtFabProps } from '../../../types/fab'
 
-export default class AtFab extends React.Component<AtFabProps> {
-  public static defaultProps: AtFabProps
-  public static propTypes: InferProps<AtFabProps>
-
-  private onClick(e: CommonEvent): void {
-    if (typeof this.props.onClick === 'function') {
-      this.props.onClick(e)
+function AtFab({
+  size = 'normal',
+  className,
+  children,
+  onClick
+}: AtFabProps): JSX.Element {
+  const handleClick = (e: CommonEvent): void => {
+    if (typeof onClick === 'function') {
+      onClick(e)
     }
   }
 
-  public render(): JSX.Element {
-    const { size, className, children } = this.props
+  const rootClass = classNames('at-fab', className, {
+    [`at-fab--${size}`]: size
+  })
 
-    const rootClass = classNames('at-fab', className, {
-      [`at-fab--${size}`]: size
-    })
-
-    return (
-      <View className={rootClass} onClick={this.onClick.bind(this)}>
-        {children}
-      </View>
-    )
-  }
+  return (
+    <View className={rootClass} onClick={handleClick}>
+      {children}
+    </View>
+  )
 }
 
 AtFab.propTypes = {
@@ -35,6 +33,4 @@ AtFab.propTypes = {
   onClick: PropTypes.func
 }
 
-AtFab.defaultProps = {
-  size: 'normal'
-}
+export default AtFab

--- a/packages/taro-ui/src/components/flex/index.tsx
+++ b/packages/taro-ui/src/components/flex/index.tsx
@@ -1,31 +1,27 @@
 import classNames from 'classnames'
 import _forEach from 'lodash/forEach'
-import PropTypes, { InferProps } from 'prop-types'
+import PropTypes from 'prop-types'
 import React from 'react'
 import { View } from '@tarojs/components'
 import { AtFlexProps } from '../../../types/flex'
 
-export default class AtFlex extends React.Component<AtFlexProps> {
-  public static propTypes: InferProps<AtFlexProps>
+function AtFlex(props: AtFlexProps): JSX.Element {
+  const rootClass = ['at-row']
 
-  public render(): JSX.Element {
-    const rootClass = ['at-row']
+  _forEach(props, (value, key) => {
+    if (key === 'children') {
+      return
+    }
+    if (key === 'alignContent') {
+      return rootClass.push(`at-row--${value}`)
+    }
+    if (key === 'alignContent') {
+      return rootClass.push(`at-row__align-content--${value}`)
+    }
+    rootClass.push(`at-row__${key}--${value}`)
+  })
 
-    _forEach(this.props, (value, key) => {
-      if (key === 'children') {
-        return
-      }
-      if (key === 'alignContent') {
-        return rootClass.push(`at-row--${value}`)
-      }
-      if (key === 'alignContent') {
-        return rootClass.push(`at-row__align-content--${value}`)
-      }
-      rootClass.push(`at-row__${key}--${value}`)
-    })
-
-    return <View className={classNames(rootClass)}>{this.props.children}</View>
-  }
+  return <View className={classNames(rootClass)}>{props.children}</View>
 }
 
 AtFlex.propTypes = {
@@ -42,3 +38,5 @@ AtFlex.propTypes = {
     'around'
   ])
 }
+
+export default AtFlex

--- a/packages/taro-ui/src/components/flex/item/index.tsx
+++ b/packages/taro-ui/src/components/flex/item/index.tsx
@@ -1,31 +1,27 @@
 import classNames from 'classnames'
 import _forEach from 'lodash/forEach'
-import PropTypes, { InferProps } from 'prop-types'
+import PropTypes from 'prop-types'
 import React from 'react'
 import { View } from '@tarojs/components'
 import { AtFlexItemProps } from '../../../../types/flex'
 
-export default class AtFlexItem extends React.Component<AtFlexItemProps> {
-  public static propTypes: InferProps<AtFlexItemProps>
+function AtFlexItem(props: AtFlexItemProps): JSX.Element {
+  const rootClass = ['at-col']
 
-  public render(): JSX.Element {
-    const rootClass = ['at-col']
+  _forEach(props, (value, key) => {
+    if (key === 'isAuto' && value) {
+      return rootClass.push('at-col--auto')
+    }
+    if (key === 'isWrap' && value) {
+      return rootClass.push('at-col--wrap')
+    }
+    if (key === 'size' && value) {
+      rootClass.push(`at-col-${value}`)
+    }
+    rootClass.push(`at-col__${key}--${value}`)
+  })
 
-    _forEach(this.props, (value, key) => {
-      if (key === 'isAuto' && value) {
-        return rootClass.push('at-col--auto')
-      }
-      if (key === 'isWrap' && value) {
-        return rootClass.push('at-col--wrap')
-      }
-      if (key === 'size' && value) {
-        rootClass.push(`at-col-${value}`)
-      }
-      rootClass.push(`at-col__${key}--${value}`)
-    })
-
-    return <View className={classNames(rootClass)}>{this.props.children}</View>
-  }
+  return <View className={classNames(rootClass)}>{props.children}</View>
 }
 
 AtFlexItem.propTypes = {
@@ -35,3 +31,5 @@ AtFlexItem.propTypes = {
   size: PropTypes.oneOf([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]),
   offset: PropTypes.oneOf([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12])
 }
+
+export default AtFlexItem

--- a/packages/taro-ui/src/components/float-layout/index.tsx
+++ b/packages/taro-ui/src/components/float-layout/index.tsx
@@ -1,125 +1,92 @@
 import classNames from 'classnames'
-import PropTypes, { InferProps } from 'prop-types'
-import React from 'react'
+import PropTypes from 'prop-types'
+import React, { useEffect, useRef, useState } from 'react'
 import { ScrollView, Text, View } from '@tarojs/components'
 import { CommonEvent } from '@tarojs/components/types/common'
-import {
-  AtFloatLayoutProps,
-  AtFloatLayoutState
-} from '../../../types/float-layout'
+import { AtFloatLayoutProps } from '../../../types/float-layout'
 import { handleTouchScroll } from '../../common/utils'
 
-export default class AtFloatLayout extends React.Component<
-  AtFloatLayoutProps,
-  AtFloatLayoutState
-> {
-  public static defaultProps: AtFloatLayoutProps
-  public static propTypes: InferProps<AtFloatLayoutProps>
+function AtFloatLayout({
+  title = '',
+  isOpened = false,
+  scrollY = true,
+  scrollX = false,
+  scrollWithAnimation = false,
+  scrollTop,
+  scrollLeft,
+  upperThreshold,
+  lowerThreshold,
+  className,
+  children,
+  onClose,
+  onScroll,
+  onScrollToLower,
+  onScrollToUpper
+}: AtFloatLayoutProps): JSX.Element {
+  const [_isOpened, setIsOpened] = useState(isOpened)
+  const prevIsOpenedPropRef = useRef(isOpened)
 
-  public constructor(props: AtFloatLayoutProps) {
-    super(props)
-
-    const { isOpened } = props
-    this.state = {
-      _isOpened: isOpened
-    }
-  }
-
-  public UNSAFE_componentWillReceiveProps(nextProps: AtFloatLayoutProps): void {
-    const { isOpened } = nextProps
-
-    if (this.props.isOpened !== isOpened) {
+  useEffect(() => {
+    if (prevIsOpenedPropRef.current !== isOpened) {
       handleTouchScroll(isOpened)
+      prevIsOpenedPropRef.current = isOpened
     }
+    setIsOpened(prev => (isOpened !== prev ? isOpened : prev))
+  }, [isOpened])
 
-    if (isOpened !== this.state._isOpened) {
-      this.setState({
-        _isOpened: isOpened
-      })
-    }
-  }
-
-  private handleClose = (e): void => {
-    if (typeof this.props.onClose === 'function') {
-      this.props.onClose(e)
+  const handleClose = (e): void => {
+    if (typeof onClose === 'function') {
+      onClose(e)
     }
   }
 
-  private close = (e): void => {
-    this.setState(
-      {
-        _isOpened: false
-      },
-      () => this.handleClose(e)
-    )
+  const close = (e): void => {
+    setIsOpened(false)
+    handleClose(e)
   }
 
-  private handleTouchMove = (e: CommonEvent): void => {
+  const handleTouchMove = (e: CommonEvent): void => {
     e.stopPropagation()
   }
 
-  public render(): JSX.Element {
-    const { _isOpened } = this.state
-    const {
-      title,
+  const rootClass = classNames(
+    'at-float-layout',
+    {
+      'at-float-layout--active': _isOpened
+    },
+    className
+  )
 
-      scrollY,
-      scrollX,
-      scrollTop,
-      scrollLeft,
-      upperThreshold,
-      lowerThreshold,
-      scrollWithAnimation
-    } = this.props
-
-    const rootClass = classNames(
-      'at-float-layout',
-      {
-        'at-float-layout--active': _isOpened
-      },
-      this.props.className
-    )
-
-    return (
-      <View className={rootClass} onTouchMove={this.handleTouchMove}>
-        <View onClick={this.close} className='at-float-layout__overlay' />
-        <View className='at-float-layout__container layout'>
-          {title ? (
-            <View className='layout-header'>
-              <Text className='layout-header__title'>{title}</Text>
-              <View className='layout-header__btn-close' onClick={this.close} />
-            </View>
-          ) : null}
-          <View className='layout-body'>
-            <ScrollView
-              scrollY={scrollY}
-              scrollX={scrollX}
-              scrollTop={scrollTop}
-              scrollLeft={scrollLeft}
-              upperThreshold={upperThreshold}
-              lowerThreshold={lowerThreshold}
-              scrollWithAnimation={scrollWithAnimation}
-              onScroll={this.props.onScroll}
-              onScrollToLower={this.props.onScrollToLower}
-              onScrollToUpper={this.props.onScrollToUpper}
-              className='layout-body__content'
-            >
-              {this.props.children}
-            </ScrollView>
+  return (
+    <View className={rootClass} onTouchMove={handleTouchMove}>
+      <View onClick={close} className='at-float-layout__overlay' />
+      <View className='at-float-layout__container layout'>
+        {title ? (
+          <View className='layout-header'>
+            <Text className='layout-header__title'>{title}</Text>
+            <View className='layout-header__btn-close' onClick={close} />
           </View>
+        ) : null}
+        <View className='layout-body'>
+          <ScrollView
+            scrollY={scrollY}
+            scrollX={scrollX}
+            scrollTop={scrollTop}
+            scrollLeft={scrollLeft}
+            upperThreshold={upperThreshold}
+            lowerThreshold={lowerThreshold}
+            scrollWithAnimation={scrollWithAnimation}
+            onScroll={onScroll}
+            onScrollToLower={onScrollToLower}
+            onScrollToUpper={onScrollToUpper}
+            className='layout-body__content'
+          >
+            {children}
+          </ScrollView>
         </View>
       </View>
-    )
-  }
-}
-
-AtFloatLayout.defaultProps = {
-  title: '',
-  isOpened: false,
-
-  scrollY: true,
-  scrollX: false,
-  scrollWithAnimation: false
+    </View>
+  )
 }
 
 AtFloatLayout.propTypes = {
@@ -137,3 +104,5 @@ AtFloatLayout.propTypes = {
   onScrollToLower: PropTypes.func,
   onScrollToUpper: PropTypes.func
 }
+
+export default AtFloatLayout

--- a/packages/taro-ui/src/components/form/index.tsx
+++ b/packages/taro-ui/src/components/form/index.tsx
@@ -2,6 +2,7 @@ import classNames from 'classnames'
 import PropTypes from 'prop-types'
 import React from 'react'
 import { Form } from '@tarojs/components'
+import { CommonEvent } from '@tarojs/components/types/common'
 import { AtFormProps } from '../../../types/form'
 
 function AtForm({
@@ -12,12 +13,12 @@ function AtForm({
   onReset,
   children
 }: AtFormProps): JSX.Element {
-  const handleSubmit = (): void => {
-    onSubmit && onSubmit(arguments as any)
+  const handleSubmit = (event: CommonEvent): void => {
+    onSubmit && onSubmit(event)
   }
 
-  const handleReset = (): void => {
-    onReset && onReset(arguments as any)
+  const handleReset = (event: CommonEvent): void => {
+    onReset && onReset(event)
   }
 
   const rootCls = classNames('at-form', className)

--- a/packages/taro-ui/src/components/form/index.tsx
+++ b/packages/taro-ui/src/components/form/index.tsx
@@ -1,43 +1,38 @@
 import classNames from 'classnames'
-import PropTypes, { InferProps } from 'prop-types'
+import PropTypes from 'prop-types'
 import React from 'react'
 import { Form } from '@tarojs/components'
 import { AtFormProps } from '../../../types/form'
 
-export default class AtForm extends React.Component<AtFormProps> {
-  public static defaultProps: AtFormProps
-  public static propTypes: InferProps<AtFormProps>
-
-  private onSubmit(): void {
-    this.props.onSubmit && this.props.onSubmit(arguments as any)
+function AtForm({
+  customStyle = '',
+  className = '',
+  reportSubmit = false,
+  onSubmit,
+  onReset,
+  children
+}: AtFormProps): JSX.Element {
+  const handleSubmit = (): void => {
+    onSubmit && onSubmit(arguments as any)
   }
 
-  private onReset(): void {
-    this.props.onReset && this.props.onReset(arguments as any)
+  const handleReset = (): void => {
+    onReset && onReset(arguments as any)
   }
 
-  public render(): JSX.Element {
-    const { customStyle, className, reportSubmit } = this.props
-    const rootCls = classNames('at-form', className)
+  const rootCls = classNames('at-form', className)
 
-    return (
-      <Form
-        className={rootCls}
-        style={customStyle}
-        onSubmit={this.onSubmit.bind(this)}
-        reportSubmit={reportSubmit}
-        onReset={this.onReset.bind(this)}
-      >
-        {this.props.children}
-      </Form>
-    )
-  }
-}
-
-AtForm.defaultProps = {
-  customStyle: '',
-  className: '',
-  reportSubmit: false
+  return (
+    <Form
+      className={rootCls}
+      style={customStyle}
+      onSubmit={handleSubmit}
+      reportSubmit={reportSubmit}
+      onReset={handleReset}
+    >
+      {children}
+    </Form>
+  )
 }
 
 AtForm.propTypes = {
@@ -47,3 +42,5 @@ AtForm.propTypes = {
   onSubmit: PropTypes.func,
   onReset: PropTypes.func
 }
+
+export default AtForm

--- a/packages/taro-ui/src/components/grid/index.tsx
+++ b/packages/taro-ui/src/components/grid/index.tsx
@@ -1,112 +1,101 @@
 import classNames from 'classnames'
 import _chunk from 'lodash/chunk'
-import PropTypes, { InferProps } from 'prop-types'
+import PropTypes from 'prop-types'
 import React from 'react'
 import { Image, Text, View } from '@tarojs/components'
 import { CommonEvent } from '@tarojs/components/types/common'
 import { AtGridItem, AtGridProps } from '../../../types/grid'
 import { mergeStyle } from '../../common/utils'
 
-export default class AtGrid extends React.Component<AtGridProps> {
-  public static defaultProps: AtGridProps
-  public static propTypes: InferProps<AtGridProps>
-
-  private handleClick = (
+function AtGrid({
+  data = [],
+  mode = 'square',
+  columnNum = 3,
+  hasBorder = true,
+  className,
+  onClick
+}: AtGridProps): JSX.Element | null {
+  const handleClick = (
     item: AtGridItem,
     index: number,
     row: number,
     event: CommonEvent
   ): void => {
-    const { onClick, columnNum = 3 } = this.props
     if (typeof onClick === 'function') {
       const clickIndex = row * columnNum + index
       onClick(item, clickIndex, event)
     }
   }
 
-  public render(): JSX.Element | null {
-    const { data, mode, columnNum = 3, hasBorder } = this.props
+  if (Array.isArray(data) && data.length === 0) {
+    return null
+  }
 
-    if (Array.isArray(data) && data.length === 0) {
-      return null
+  const gridGroup = _chunk(data, columnNum)
+
+  const bodyClass = classNames(
+    ['at-grid__flex-item', 'at-grid-item', `at-grid-item--${mode}`],
+    {
+      'at-grid-item--no-border': !hasBorder
     }
+  )
 
-    const gridGroup = _chunk(data, columnNum)
-
-    const bodyClass = classNames(
-      ['at-grid__flex-item', 'at-grid-item', `at-grid-item--${mode}`],
-      {
-        'at-grid-item--no-border': !hasBorder
-      }
-    )
-
-    return (
-      <View className={classNames('at-grid', this.props.className)}>
-        {gridGroup.map((item, i) => (
-          <View className='at-grid__flex' key={`at-grid-group-${i}`}>
-            {item.map((childItem, index) => (
-              <View
-                key={`at-grid-item-${index}`}
-                className={classNames(bodyClass, {
-                  'at-grid-item--last': index === columnNum - 1
-                })}
-                onClick={this.handleClick.bind(this, childItem, index, i)}
-                style={{
-                  flex: `0 0 ${100 / columnNum}%`
-                }}
-              >
-                <View className='at-grid-item__content'>
-                  <View className='at-grid-item__content-inner'>
-                    <View className='content-inner__icon'>
-                      {childItem.image && (
-                        <Image
-                          className='content-inner__img'
-                          src={childItem.image}
-                          mode='scaleToFill'
-                        />
-                      )}
-                      {childItem.iconInfo && !childItem.image && (
-                        <Text
-                          className={classNames(
-                            childItem.iconInfo.prefixClass || 'at-icon',
-                            {
-                              [`${
-                                childItem.iconInfo.prefixClass || 'at-icon'
-                              }-${childItem.iconInfo.value}`]:
-                                childItem.iconInfo.value
-                            },
-                            childItem.iconInfo.className
-                          )}
-                          style={mergeStyle(
-                            {
-                              color: childItem.iconInfo.color,
-                              fontSize: `${childItem.iconInfo.size || 24}px`
-                            },
-                            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                            childItem.iconInfo!.customStyle!
-                          )}
-                        />
-                      )}
-                    </View>
-                    <Text className='content-inner__text'>
-                      {childItem.value}
-                    </Text>
+  return (
+    <View className={classNames('at-grid', className)}>
+      {gridGroup.map((item, i) => (
+        <View className='at-grid__flex' key={`at-grid-group-${i}`}>
+          {item.map((childItem, index) => (
+            <View
+              key={`at-grid-item-${index}`}
+              className={classNames(bodyClass, {
+                'at-grid-item--last': index === columnNum - 1
+              })}
+              onClick={event => handleClick(childItem, index, i, event)}
+              style={{
+                flex: `0 0 ${100 / columnNum}%`
+              }}
+            >
+              <View className='at-grid-item__content'>
+                <View className='at-grid-item__content-inner'>
+                  <View className='content-inner__icon'>
+                    {childItem.image && (
+                      <Image
+                        className='content-inner__img'
+                        src={childItem.image}
+                        mode='scaleToFill'
+                      />
+                    )}
+                    {childItem.iconInfo && !childItem.image && (
+                      <Text
+                        className={classNames(
+                          childItem.iconInfo.prefixClass || 'at-icon',
+                          {
+                            [`${childItem.iconInfo.prefixClass || 'at-icon'}-${
+                              childItem.iconInfo.value
+                            }`]: childItem.iconInfo.value
+                          },
+                          childItem.iconInfo.className
+                        )}
+                        style={mergeStyle(
+                          {
+                            color: childItem.iconInfo.color,
+                            fontSize: `${childItem.iconInfo.size || 24}px`
+                          },
+                          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                          childItem.iconInfo!.customStyle!
+                        )}
+                      />
+                    )}
                   </View>
+                  <Text className='content-inner__text'>{childItem.value}</Text>
                 </View>
               </View>
-            ))}
-          </View>
-        ))}
-      </View>
-    )
-  }
-}
-
-AtGrid.defaultProps = {
-  data: [],
-  columnNum: 3,
-  mode: 'square',
-  hasBorder: true
+            </View>
+          ))}
+        </View>
+      ))}
+    </View>
+  )
 }
 
 AtGrid.propTypes = {
@@ -129,3 +118,5 @@ AtGrid.propTypes = {
     })
   )
 }
+
+export default AtGrid

--- a/packages/taro-ui/src/components/icon/index.tsx
+++ b/packages/taro-ui/src/components/icon/index.tsx
@@ -1,51 +1,36 @@
 import classNames from 'classnames'
-import PropTypes, { InferProps } from 'prop-types'
+import PropTypes from 'prop-types'
 import React from 'react'
 import { Text } from '@tarojs/components'
 import { AtIconProps } from '../../../types/icon'
 import { mergeStyle, pxTransform } from '../../common/utils'
 
-export default class AtIcon extends React.Component<AtIconProps> {
-  public static defaultProps: AtIconProps
-  public static propTypes: InferProps<AtIconProps>
-
-  private handleClick(): void {
-    this.props.onClick && this.props.onClick(arguments as any)
+export default function AtIcon({
+  customStyle = {},
+  className = '',
+  prefixClass = 'at-icon',
+  value = '',
+  color = '',
+  size = 24,
+  onClick
+}: AtIconProps): JSX.Element {
+  function handleClick(): void {
+    onClick && onClick(arguments as any)
   }
 
-  public render(): JSX.Element {
-    const {
-      customStyle = {},
-      className,
-      prefixClass,
-      value,
-      size,
-      color
-    } = this.props
-
-    const rootStyle = {
-      fontSize: `${pxTransform(parseInt(String(size)) * 2)}`,
-      color
-    }
-
-    const iconName = value ? `${prefixClass}-${value}` : ''
-    return (
-      <Text
-        className={classNames(prefixClass, iconName, className)}
-        style={mergeStyle(rootStyle, customStyle)}
-        onClick={this.handleClick.bind(this)}
-      ></Text>
-    )
+  const rootStyle = {
+    fontSize: `${pxTransform(parseInt(String(size)) * 2)}`,
+    color
   }
-}
 
-AtIcon.defaultProps = {
-  customStyle: '',
-  className: '',
-  prefixClass: 'at-icon',
-  value: '',
-  color: '',
-  size: 24
+  const iconName = value ? `${prefixClass}-${value}` : ''
+  return (
+    <Text
+      className={classNames(prefixClass, iconName, className)}
+      style={mergeStyle(rootStyle, customStyle)}
+      onClick={handleClick}
+    ></Text>
+  )
 }
 
 AtIcon.propTypes = {

--- a/packages/taro-ui/src/components/image-picker/index.tsx
+++ b/packages/taro-ui/src/components/image-picker/index.tsx
@@ -1,11 +1,11 @@
 import classNames from 'classnames'
-import PropTypes, { InferProps } from 'prop-types'
+import PropTypes from 'prop-types'
 import React from 'react'
 import { Image, View } from '@tarojs/components'
 import { ITouchEvent } from '@tarojs/components/types/common'
 import Taro from '@tarojs/taro'
 import { AtImagePickerProps, File } from '../../../types/image-picker'
-import { uuid } from '../../common/utils'
+import { noop, uuid } from '../../common/utils'
 
 interface MatrixFile extends Partial<File> {
   type: 'blank' | 'btn'
@@ -42,14 +42,25 @@ const generateMatrix = (
   return matrix
 }
 
-const ENV = Taro.getEnv()
+function AtImagePicker({
+  className = '',
+  customStyle = '',
+  files = [],
+  mode = 'aspectFill',
+  showAddBtn = true,
+  multiple = false,
+  length = 4,
+  count,
+  sizeType,
+  sourceType,
+  onChange = noop,
+  onImageClick,
+  onFail,
+  children
+}: AtImagePickerProps): JSX.Element {
+  const ENV = Taro.getEnv()
 
-export default class AtImagePicker extends React.Component<AtImagePickerProps> {
-  public static defaultProps: AtImagePickerProps
-  public static propTypes: InferProps<AtImagePickerProps>
-
-  private chooseFile = (): void => {
-    const { files = [], multiple, count, sizeType, sourceType } = this.props
+  const chooseFile = (): void => {
     const filePathName =
       ENV === Taro.ENV_TYPE.ALIPAY ? 'apFilePaths' : 'tempFiles'
     // const count = multiple ? 99 : 1
@@ -73,101 +84,76 @@ export default class AtImagePicker extends React.Component<AtImagePickerProps> {
           file: res[filePathName][i]
         }))
         const newFiles = files.concat(targetFiles)
-        this.props.onChange(newFiles, 'add')
+        onChange(newFiles, 'add')
       })
       .catch(err => {
-        this.props?.onFail?.(err)
+        onFail?.(err)
       })
   }
 
-  private handleImageClick = (idx: number): void => {
-    this.props.onImageClick &&
-      this.props.onImageClick(idx, this.props.files[idx])
+  const handleImageClick = (idx: number): void => {
+    onImageClick && onImageClick(idx, files[idx])
   }
 
-  private handleRemoveImg = (idx: number, event: ITouchEvent): void => {
+  const handleRemoveImg = (idx: number, event: ITouchEvent): void => {
     event.stopPropagation()
     event.preventDefault()
-    const { files = [] } = this.props
     if (ENV === Taro.ENV_TYPE.WEB) {
       window.URL.revokeObjectURL(files[idx].url)
     }
     const newFiles = files.filter((_, i) => i !== idx)
-    this.props.onChange(newFiles, 'remove', idx)
+    onChange(newFiles, 'remove', idx)
   }
 
-  public render(): JSX.Element {
-    const {
-      className,
-      customStyle,
-      files,
-      mode,
-      length = 4,
-      showAddBtn = true
-    } = this.props
-    const rowLength = length <= 0 ? 1 : length
-    // 行数
-    const matrix = generateMatrix(files as MatrixFile[], rowLength, showAddBtn)
-    const rootCls = classNames('at-image-picker', className)
+  const rowLength = length <= 0 ? 1 : length
+  // 行数
+  const matrix = generateMatrix(files as MatrixFile[], rowLength, showAddBtn)
+  const rootCls = classNames('at-image-picker', className)
 
-    return (
-      <View className={rootCls} style={customStyle}>
-        {matrix.map((row, i) => (
-          <View className='at-image-picker__flex-box' key={i + 1}>
-            {row.map((item, j) =>
-              item.url ? (
-                <View
-                  className='at-image-picker__flex-item'
-                  key={i * length + j}
-                >
-                  <View className='at-image-picker__item'>
-                    <View
-                      className='at-image-picker__remove-btn'
-                      onClick={this.handleRemoveImg.bind(this, i * length + j)}
-                    ></View>
-                    <Image
-                      className='at-image-picker__preview-img'
-                      mode={mode}
-                      src={item.url}
-                      onClick={this.handleImageClick.bind(this, i * length + j)}
-                    />
+  return (
+    <View className={rootCls} style={customStyle}>
+      {matrix.map((row, i) => (
+        <View className='at-image-picker__flex-box' key={i + 1}>
+          {row.map((item, j) =>
+            item.url ? (
+              <View className='at-image-picker__flex-item' key={i * length + j}>
+                <View className='at-image-picker__item'>
+                  <View
+                    className='at-image-picker__remove-btn'
+                    onClick={(event: ITouchEvent) =>
+                      handleRemoveImg(i * length + j, event)
+                    }
+                  ></View>
+                  <Image
+                    className='at-image-picker__preview-img'
+                    mode={mode}
+                    src={item.url}
+                    onClick={() => handleImageClick(i * length + j)}
+                  />
+                </View>
+              </View>
+            ) : (
+              <View
+                className='at-image-picker__flex-item'
+                key={`empty_${i * length}${j}`}
+              >
+                {item.type === 'btn' && (
+                  <View onClick={chooseFile}>
+                    {children || (
+                      <View className='at-image-picker__item at-image-picker__choose-btn'>
+                        <View className='add-bar'></View>
+                        <View className='add-bar'></View>
+                      </View>
+                    )}
                   </View>
-                </View>
-              ) : (
-                <View
-                  className='at-image-picker__flex-item'
-                  key={`empty_${i * length}${j}`}
-                >
-                  {item.type === 'btn' && (
-                    <View onClick={this.chooseFile}>
-                      {this.props.children || (
-                        <View className='at-image-picker__item at-image-picker__choose-btn'>
-                          <View className='add-bar'></View>
-                          <View className='add-bar'></View>
-                        </View>
-                      )}
-                    </View>
-                  )}
-                </View>
-              )
-            )}
-          </View>
-        ))}
-      </View>
-    )
-  }
-}
-
-AtImagePicker.defaultProps = {
-  className: '',
-  customStyle: '',
-  files: [],
-  mode: 'aspectFill',
-  showAddBtn: true,
-  multiple: false,
-  length: 4,
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  onChange: (): void => {}
+                )}
+              </View>
+            )
+          )}
+        </View>
+      ))}
+    </View>
+  )
 }
 
 AtImagePicker.propTypes = {
@@ -199,3 +185,5 @@ AtImagePicker.propTypes = {
   sizeType: PropTypes.array,
   sourceType: PropTypes.array
 }
+
+export default AtImagePicker

--- a/packages/taro-ui/src/components/indexes/index.tsx
+++ b/packages/taro-ui/src/components/indexes/index.tsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames'
-import PropTypes, { InferProps } from 'prop-types'
-import React from 'react'
+import PropTypes from 'prop-types'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { ScrollView, View } from '@tarojs/components'
 import { CommonEvent, ITouchEvent } from '@tarojs/components/types/common'
 import Taro from '@tarojs/taro'
@@ -17,134 +17,105 @@ import AtToast from '../toast/index'
 
 const ENV = Taro.getEnv()
 
-export default class AtIndexes extends React.Component<
-  AtIndexesProps,
-  AtIndexesState
-> {
-  public static defaultProps: AtIndexesProps
-  public static propTypes: InferProps<AtIndexesProps>
+function AtIndexes({
+  customStyle = '',
+  className = '',
+  animation = false,
+  topKey = 'Top',
+  isVibrate = true,
+  isShowToast = true,
+  list = [],
+  onClick,
+  onScrollIntoView,
+  children
+}: AtIndexesProps): JSX.Element {
+  const [_scrollIntoView, setScrollIntoView] = useState('')
+  const [_scrollTop, setScrollTop] = useState(0)
+  const [_tipText, setTipText] = useState('')
+  const [_isShowToast, setIsShowToast] = useState(false)
+  const isWEB = Taro.getEnv() === Taro.ENV_TYPE.WEB
+  const [currentIndex, setCurrentIndex] = useState(-1)
 
-  private menuHeight: number
-  private startTop: number
-  private itemHeight: number
-  private currentIndex: number
-  private listId: string
-  private timeoutTimer: NodeJS.Timeout | number | undefined
-  private listRef: any
-  private indexMap: { key: string; startHeight: number; endHeight: number }[]
+  const menuHeightRef = useRef(0)
+  const startTopRef = useRef(0)
+  const itemHeightRef = useRef(0)
+  const touchCurrentIndexRef = useRef(-1)
+  const [listId] = useState(() =>
+    isTest() ? 'indexes-list-AOTU2018' : `list-${uuid()}`
+  )
+  const timeoutTimerRef = useRef<NodeJS.Timeout | number>()
+  const listRef = useRef<HTMLElement | null>(null)
+  const indexMapRef = useRef<
+    { key: string; startHeight: number; endHeight: number }[]
+  >([])
 
-  public constructor(props: AtIndexesProps) {
-    super(props)
-    this.state = {
-      _scrollIntoView: '',
-      _scrollTop: 0,
-      _tipText: '',
-      _isShowToast: false,
-      isWEB: Taro.getEnv() === Taro.ENV_TYPE.WEB,
-      currentIndex: -1
-    }
-    // 右侧导航高度
-    this.menuHeight = 0
-    // 右侧导航距离顶部高度
-    this.startTop = 0
-    // 右侧导航元素高度
-    this.itemHeight = 0
-    // 当前索引
-    this.currentIndex = -1
-    this.listId = isTest() ? 'indexes-list-AOTU2018' : `list-${uuid()}`
-    this.indexMap = []
-  }
+  const updateState = useCallback(
+    (state: Partial<AtIndexesState>): void => {
+      const {
+        _scrollIntoView: nextScrollIntoView,
+        _tipText: nextTipText,
+        _scrollTop: nextScrollTop
+      } = state
+      setScrollIntoView(nextScrollIntoView!)
+      setTipText(nextTipText!)
+      setScrollTop(nextScrollTop!)
+      setIsShowToast(isShowToast!)
 
-  private handleClick = (item: Item): void => {
-    this.props.onClick && this.props.onClick(item)
-  }
+      clearTimeout(timeoutTimerRef.current as number)
+      timeoutTimerRef.current = setTimeout(() => {
+        setTipText('')
+        setIsShowToast(false)
+      }, 3000)
 
-  private handleTouchMove = (event: ITouchEvent): void => {
-    event.stopPropagation()
-    event.preventDefault()
-
-    const { list } = this.props
-    const pageY = event.touches[0].pageY
-    const index = Math.floor((pageY - this.startTop) / this.itemHeight)
-
-    if (index >= 0 && index <= list.length && this.currentIndex !== index) {
-      this.currentIndex = index
-      const key = index > 0 ? list[index - 1].key : 'top'
-      const touchView = `at-indexes__list-${key}`
-      this.jumpTarget(touchView, index)
-    }
-  }
-
-  private handleTouchEnd = (): void => {
-    this.currentIndex = -1
-  }
-
-  private jumpTarget(_scrollIntoView: string, idx: number): void {
-    const { topKey = 'Top', list } = this.props
-    const _tipText = idx === 0 ? topKey : list[idx - 1].key
-
-    if (ENV === Taro.ENV_TYPE.WEB) {
-      delayQuerySelector('.at-indexes', 0).then(rect => {
-        const targetOffsetTop = this.listRef.children[idx].offsetTop
-        const _scrollTop = targetOffsetTop - rect[0].top
-        this.updateState({
-          _scrollTop,
-          _scrollIntoView,
-          _tipText
-        })
-      })
-      return
-    }
-
-    this.updateState({
-      _scrollIntoView,
-      _tipText
-    })
-  }
-
-  private __jumpTarget(key: string): void {
-    const { list } = this.props
-    // const index = _findIndex(list, ['key', key])
-    const index = list.findIndex(item => item.key === key)
-    const targetView = `at-indexes__list-${key}`
-    this.jumpTarget(targetView, index + 1)
-  }
-
-  private updateState(state: Partial<AtIndexesState>): void {
-    const { isShowToast, isVibrate } = this.props
-    const { _scrollIntoView, _tipText, _scrollTop } = state
-    // TODO: Fix dirty hack
-    /* eslint-disable @typescript-eslint/no-non-null-assertion */
-    this.setState(
-      {
-        _scrollIntoView: _scrollIntoView!,
-        _tipText: _tipText!,
-        _scrollTop: _scrollTop!,
-        _isShowToast: isShowToast!
-      },
-      /* eslint-enable @typescript-eslint/no-non-null-assertion */
-      () => {
-        clearTimeout(this.timeoutTimer as number)
-        this.timeoutTimer = setTimeout(() => {
-          this.setState({
-            _tipText: '',
-            _isShowToast: false
-          })
-        }, 3000)
+      if (isVibrate) {
+        Taro.vibrateShort()
       }
-    )
+    },
+    [isShowToast, isVibrate]
+  )
 
-    if (isVibrate) {
-      Taro.vibrateShort()
-    }
-  }
+  const jumpTarget = useCallback(
+    (_scrollIntoViewTarget: string, idx: number): void => {
+      const _tipTextValue = idx === 0 ? topKey : list[idx - 1].key
 
-  private async initData(): Promise<void> {
+      if (ENV === Taro.ENV_TYPE.WEB) {
+        delayQuerySelector('.at-indexes', 0).then(rect => {
+          const targetOffsetTop = (
+            listRef.current!.children[idx] as HTMLElement
+          ).offsetTop
+          const _scrollTopValue = targetOffsetTop - rect[0].top
+          updateState({
+            _scrollTop: _scrollTopValue,
+            _scrollIntoView: _scrollIntoViewTarget,
+            _tipText: _tipTextValue
+          })
+        })
+        return
+      }
+
+      updateState({
+        _scrollIntoView: _scrollIntoViewTarget,
+        _tipText: _tipTextValue
+      })
+    },
+    [list, topKey, updateState]
+  )
+
+  const jumpTargetByKey = useCallback(
+    (key: string): void => {
+      const index = list.findIndex(item => item.key === key)
+      const targetView = `at-indexes__list-${key}`
+      jumpTarget(targetView, index + 1)
+    },
+    [list, jumpTarget]
+  )
+
+  const initData = useCallback(async (): Promise<void> => {
     delayQuerySelector('.at-indexes__menu').then(rect => {
-      const len = this.props.list.length
-      this.menuHeight = rect[0].height
-      this.startTop = rect[0].top
-      this.itemHeight = Math.floor(this.menuHeight / (len + 1))
+      const len = list.length
+      menuHeightRef.current = rect[0].height
+      startTopRef.current = rect[0].top
+      itemHeightRef.current = Math.floor(menuHeightRef.current / (len + 1))
     })
 
     const headerHeight =
@@ -154,18 +125,18 @@ export default class AtIndexes extends React.Component<
     const titleHeight =
       (await delayQuerySelector('.at-indexes__list-title'))?.[0].height || 0
 
-    this.indexMap = []
-    this.props.list.forEach((dataList, i) => {
+    indexMapRef.current = []
+    list.forEach((dataList, i) => {
       if (i === 0) {
-        this.indexMap.push({
+        indexMapRef.current.push({
           key: dataList.key,
           startHeight: headerHeight,
           endHeight:
             dataList.items.length * itemHeight + headerHeight + titleHeight
         })
       } else {
-        const prev = this.indexMap[i - 1]
-        this.indexMap.push({
+        const prev = indexMapRef.current[i - 1]
+        indexMapRef.current.push({
           key: dataList.key,
           startHeight: prev.endHeight,
           endHeight:
@@ -173,138 +144,151 @@ export default class AtIndexes extends React.Component<
         })
       }
     })
-  }
+  }, [list])
 
-  private handleScroll(e: CommonEvent): void {
-    if (e && e.detail) {
-      const scrollTop = e.detail.scrollTop
-
-      this.setState({
-        _scrollTop: scrollTop
-      })
-
-      this.getAnchorIndex(scrollTop)
-    }
-  }
-
-  // 根据滚动高度，判断当前应该显示的索引值
-  private getAnchorIndex(scrollTop: number) {
-    const index = this.indexMap.findIndex(item => {
+  const getAnchorIndex = useCallback((scrollTop: number): void => {
+    const index = indexMapRef.current.findIndex(item => {
       return scrollTop >= item.startHeight && scrollTop < item.endHeight
     })
 
-    this.setState({
-      currentIndex: index
-    })
+    setCurrentIndex(index)
+  }, [])
+
+  const handleClick = (item: Item): void => {
+    onClick && onClick(item)
   }
 
-  public UNSAFE_componentWillReceiveProps(nextProps: AtIndexesProps): void {
-    if (nextProps.list.length !== this.props.list.length) {
-      this.initData()
+  const handleTouchMove = (event: ITouchEvent): void => {
+    event.stopPropagation()
+    event.preventDefault()
+
+    const pageY = event.touches[0].pageY
+    const index = Math.floor(
+      (pageY - startTopRef.current) / itemHeightRef.current
+    )
+
+    if (
+      index >= 0 &&
+      index <= list.length &&
+      touchCurrentIndexRef.current !== index
+    ) {
+      touchCurrentIndexRef.current = index
+      const key = index > 0 ? list[index - 1].key : 'top'
+      const touchView = `at-indexes__list-${key}`
+      jumpTarget(touchView, index)
     }
   }
 
-  public componentDidMount(): void {
+  const handleTouchEnd = (): void => {
+    touchCurrentIndexRef.current = -1
+  }
+
+  const handleScroll = (e: CommonEvent): void => {
+    if (e && e.detail) {
+      const scrollTop = e.detail.scrollTop
+
+      setScrollTop(scrollTop)
+
+      getAnchorIndex(scrollTop)
+    }
+  }
+
+  useEffect(() => {
+    onScrollIntoView && onScrollIntoView(jumpTargetByKey)
+  }, [onScrollIntoView, jumpTargetByKey])
+
+  const listLengthRef = useRef(list.length)
+
+  useEffect(() => {
     if (ENV === Taro.ENV_TYPE.WEB) {
-      this.listRef = document.getElementById(this.listId)
+      listRef.current = document.getElementById(listId)
     }
-    this.initData()
-  }
+    initData()
+  }, [listId, initData])
 
-  public UNSAFE_componentWillMount(): void {
-    this.props.onScrollIntoView &&
-      this.props.onScrollIntoView(this.__jumpTarget.bind(this))
-  }
+  useEffect(() => {
+    if (listLengthRef.current === list.length) return
+    listLengthRef.current = list.length
+    initData()
+  }, [list.length, initData])
 
-  public render(): JSX.Element {
-    const { className, customStyle, animation, topKey, list } = this.props
-    const {
-      _scrollTop,
-      _scrollIntoView,
-      _tipText,
-      _isShowToast,
-      isWEB,
-      currentIndex
-    } = this.state
+  const toastStyle = { minWidth: pxTransform(100) }
+  const rootCls = classNames('at-indexes', className)
 
-    const toastStyle = { minWidth: pxTransform(100) }
-    const rootCls = classNames('at-indexes', className)
-
-    const menuList = list.map((dataList, i) => {
-      const { key } = dataList
-      const targetView = `at-indexes__list-${key}`
-      return (
-        <View
-          className={classNames('at-indexes__menu-item', {
-            'at-indexes__menu-item--active': currentIndex === i
-          })}
-          key={key}
-          onClick={this.jumpTarget.bind(this, targetView, i + 1)}
-        >
-          {key}
-        </View>
-      )
-    })
-
-    const indexesList = list.map(dataList => (
-      <View
-        id={`at-indexes__list-${dataList.key}`}
-        className='at-indexes__list'
-        key={dataList.key}
-      >
-        <View className='at-indexes__list-title'>{dataList.title}</View>
-        <AtList>
-          {dataList.items &&
-            dataList.items.map(item => (
-              <AtListItem
-                key={item.name}
-                title={item.name}
-                onClick={this.handleClick.bind(this, item)}
-              />
-            ))}
-        </AtList>
-      </View>
-    ))
-
+  const menuList = list.map((dataList, i) => {
+    const { key } = dataList
+    const targetView = `at-indexes__list-${key}`
     return (
-      <View className={rootCls} style={customStyle}>
-        <AtToast
-          customStyle={toastStyle}
-          isOpened={_isShowToast}
-          text={_tipText}
-          duration={2000}
-        />
-        <View
-          className='at-indexes__menu'
-          onTouchMove={this.handleTouchMove}
-          onTouchEnd={this.handleTouchEnd}
-        >
-          <View
-            className='at-indexes__menu-item'
-            onClick={this.jumpTarget.bind(this, 'at-indexes__top', 0)}
-          >
-            {topKey}
-          </View>
-          {menuList}
-        </View>
-        <ScrollView
-          className='at-indexes__body'
-          id={this.listId}
-          scrollY
-          scrollWithAnimation={animation}
-          // eslint-disable-next-line no-undefined
-          scrollTop={isWEB ? _scrollTop : undefined}
-          scrollIntoView={!isWEB ? _scrollIntoView : ''}
-          onScroll={this.handleScroll.bind(this)}
-        >
-          <View className='at-indexes__content' id='at-indexes__top'>
-            {this.props.children}
-          </View>
-          {indexesList}
-        </ScrollView>
+      <View
+        className={classNames('at-indexes__menu-item', {
+          'at-indexes__menu-item--active': currentIndex === i
+        })}
+        key={key}
+        onClick={(): void => jumpTarget(targetView, i + 1)}
+      >
+        {key}
       </View>
     )
-  }
+  })
+
+  const indexesList = list.map(dataList => (
+    <View
+      id={`at-indexes__list-${dataList.key}`}
+      className='at-indexes__list'
+      key={dataList.key}
+    >
+      <View className='at-indexes__list-title'>{dataList.title}</View>
+      <AtList>
+        {dataList.items &&
+          dataList.items.map(item => (
+            <AtListItem
+              key={item.name}
+              title={item.name}
+              onClick={(): void => handleClick(item)}
+            />
+          ))}
+      </AtList>
+    </View>
+  ))
+
+  return (
+    <View className={rootCls} style={customStyle}>
+      <AtToast
+        customStyle={toastStyle}
+        isOpened={_isShowToast}
+        text={_tipText}
+        duration={2000}
+      />
+      <View
+        className='at-indexes__menu'
+        onTouchMove={handleTouchMove}
+        onTouchEnd={handleTouchEnd}
+      >
+        <View
+          className='at-indexes__menu-item'
+          onClick={(): void => jumpTarget('at-indexes__top', 0)}
+        >
+          {topKey}
+        </View>
+        {menuList}
+      </View>
+      <ScrollView
+        className='at-indexes__body'
+        id={listId}
+        scrollY
+        scrollWithAnimation={animation}
+        // eslint-disable-next-line no-undefined
+        scrollTop={isWEB ? _scrollTop : undefined}
+        scrollIntoView={!isWEB ? _scrollIntoView : ''}
+        onScroll={handleScroll}
+      >
+        <View className='at-indexes__content' id='at-indexes__top'>
+          {children}
+        </View>
+        {indexesList}
+      </ScrollView>
+    </View>
+  )
 }
 
 AtIndexes.propTypes = {
@@ -319,12 +303,4 @@ AtIndexes.propTypes = {
   onScrollIntoView: PropTypes.func
 }
 
-AtIndexes.defaultProps = {
-  customStyle: '',
-  className: '',
-  animation: false,
-  topKey: 'Top',
-  isVibrate: true,
-  isShowToast: true,
-  list: []
-}
+export default AtIndexes

--- a/packages/taro-ui/src/components/input-number/index.tsx
+++ b/packages/taro-ui/src/components/input-number/index.tsx
@@ -1,11 +1,11 @@
 import classNames from 'classnames'
 import _toString from 'lodash/toString'
-import PropTypes, { InferProps } from 'prop-types'
+import PropTypes from 'prop-types'
 import React from 'react'
 import { Input, Text, View } from '@tarojs/components'
 import { CommonEvent, ITouchEvent } from '@tarojs/components/types/common'
 import { AtInputNumberProps, InputError } from '../../../types/input-number'
-import { pxTransform } from '../../common/utils'
+import { noop, pxTransform } from '../../common/utils'
 
 // TODO: Check all types
 
@@ -44,50 +44,42 @@ type ExtendEvent = {
   }
 }
 
-export default class AtInputNumber extends React.Component<AtInputNumberProps> {
-  public static defaultProps: AtInputNumberProps
-  public static propTypes: InferProps<AtInputNumberProps>
-
-  private handleClick(clickType: 'minus' | 'plus', e: CommonEvent): void {
-    const { disabled, value, min = 0, max = 100, step = 1 } = this.props
-    const lowThanMin = clickType === 'minus' && Number(value) <= min
-    const overThanMax = clickType === 'plus' && Number(value) >= max
-    if (lowThanMin || overThanMax || disabled) {
-      const deltaValue = clickType === 'minus' ? -step : step
-      const errorValue = addNum(Number(value), deltaValue)
-      if (disabled) {
-        this.handleError({
-          type: 'DISABLED',
-          errorValue
-        })
-      } else {
-        this.handleError({
-          type: lowThanMin ? 'LOW' : 'OVER',
-          errorValue
-        })
-      }
+function AtInputNumber({
+  customStyle = {},
+  className = '',
+  disabled = false,
+  disabledInput = false,
+  type = 'number',
+  width = 0,
+  min = 0,
+  max = 100,
+  step = 1,
+  size = 'normal',
+  value,
+  onChange = noop,
+  onBlur,
+  onErrorInput
+}: AtInputNumberProps): JSX.Element {
+  const handleError = (errorValue: InputError): void => {
+    if (!onErrorInput) {
       return
     }
-    const deltaValue = clickType === 'minus' ? -step : step
-    let newValue = addNum(Number(value), deltaValue)
-    newValue = Number(this.handleValue(newValue))
-    this.props.onChange(newValue, e)
+    onErrorInput(errorValue)
   }
 
-  private handleValue = (value: string | number): string => {
-    const { max = 100, min = 0 } = this.props
-    let resultValue = value === '' ? min : value
+  const handleValue = (val: string | number): string => {
+    let resultValue = val === '' ? min : val
     // 此处不能使用 Math.max，会是字符串变数字，并丢失 .
     if (Number(resultValue) > max) {
       resultValue = max
-      this.handleError({
+      handleError({
         type: 'OVER',
         errorValue: resultValue
       })
     }
     if (Number(resultValue) < min) {
       resultValue = min
-      this.handleError({
+      handleError({
         type: 'LOW',
         errorValue: resultValue
       })
@@ -95,7 +87,7 @@ export default class AtInputNumber extends React.Component<AtInputNumberProps> {
     if (resultValue && !Number(resultValue)) {
       resultValue = parseFloat(String(resultValue)) || min
 
-      this.handleError({
+      handleError({
         type: 'OVER',
         errorValue: resultValue
       })
@@ -105,102 +97,88 @@ export default class AtInputNumber extends React.Component<AtInputNumberProps> {
     return resultValue
   }
 
-  private handleInput = (e: CommonEvent & ExtendEvent): string => {
-    const { value } = e.target
-    const { disabled } = this.props
+  const handleClick = (clickType: 'minus' | 'plus', e: CommonEvent): void => {
+    const lowThanMin = clickType === 'minus' && Number(value) <= min
+    const overThanMax = clickType === 'plus' && Number(value) >= max
+    if (lowThanMin || overThanMax || disabled) {
+      const deltaValue = clickType === 'minus' ? -step : step
+      const errorValue = addNum(Number(value), deltaValue)
+      if (disabled) {
+        handleError({
+          type: 'DISABLED',
+          errorValue
+        })
+      } else {
+        handleError({
+          type: lowThanMin ? 'LOW' : 'OVER',
+          errorValue
+        })
+      }
+      return
+    }
+    const deltaValue = clickType === 'minus' ? -step : step
+    let newValue = addNum(Number(value), deltaValue)
+    newValue = Number(handleValue(newValue))
+    onChange(newValue, e)
+  }
+
+  const handleInput = (e: CommonEvent & ExtendEvent): string => {
+    const { value: inputVal } = e.target
     if (disabled) return ''
 
-    const newValue = this.handleValue(value)
-    this.props.onChange(Number(newValue), e)
+    const newValue = handleValue(inputVal)
+    onChange(Number(newValue), e)
     return newValue
   }
 
-  private handleBlur = (event: ITouchEvent): void =>
-    this.props.onBlur && this.props.onBlur(event)
+  const handleBlur = (event: ITouchEvent): void => onBlur && onBlur(event)
 
-  private handleError = (errorValue: InputError): void => {
-    if (!this.props.onErrorInput) {
-      return
-    }
-    this.props.onErrorInput(errorValue)
+  const inputStyle = {
+    width: width ? `${pxTransform(width)}` : ''
   }
+  const inputValue =
+    typeof value !== 'undefined' ? Number(handleValue(value)) : null
+  const rootCls = classNames(
+    'at-input-number',
+    {
+      'at-input-number--lg': size === 'large'
+    },
+    className
+  )
+  const minusBtnCls = classNames('at-input-number__btn', {
+    'at-input-number--disabled':
+      (inputValue !== null && inputValue <= min) || disabled
+  })
+  const plusBtnCls = classNames('at-input-number__btn', {
+    'at-input-number--disabled':
+      (inputValue !== null && inputValue >= max) || disabled
+  })
 
-  public render(): JSX.Element {
-    const {
-      customStyle,
-      className,
-      width,
-      disabled,
-      value,
-      type,
-      min = 0,
-      max = 100,
-      size,
-      disabledInput
-    } = this.props
-
-    const inputStyle = {
-      width: width ? `${pxTransform(width)}` : ''
-    }
-    const inputValue =
-      typeof value !== 'undefined' ? Number(this.handleValue(value)) : null
-    const rootCls = classNames(
-      'at-input-number',
-      {
-        'at-input-number--lg': size === 'large'
-      },
-      className
-    )
-    const minusBtnCls = classNames('at-input-number__btn', {
-      'at-input-number--disabled':
-        (inputValue !== null && inputValue <= min) || disabled
-    })
-    const plusBtnCls = classNames('at-input-number__btn', {
-      'at-input-number--disabled':
-        (inputValue !== null && inputValue >= max) || disabled
-    })
-
-    return (
-      <View className={rootCls} style={customStyle}>
-        <View
-          className={minusBtnCls}
-          onClick={this.handleClick.bind(this, 'minus')}
-        >
-          <Text className='at-icon at-icon-subtract at-input-number__btn-subtract'></Text>
-        </View>
-        <Input
-          className='at-input-number__input'
-          style={inputStyle}
-          type={type}
-          value={inputValue !== null ? String(inputValue) : ''}
-          disabled={disabledInput || disabled}
-          onInput={this.handleInput}
-          onBlur={this.handleBlur}
-        />
-        <View
-          className={plusBtnCls}
-          onClick={this.handleClick.bind(this, 'plus')}
-        >
-          <Text className='at-icon at-icon-add at-input-number__btn-add'></Text>
-        </View>
+  return (
+    <View className={rootCls} style={customStyle}>
+      <View
+        className={minusBtnCls}
+        onClick={(e: CommonEvent) => handleClick('minus', e)}
+      >
+        <Text className='at-icon at-icon-subtract at-input-number__btn-subtract'></Text>
       </View>
-    )
-  }
-}
-
-AtInputNumber.defaultProps = {
-  customStyle: {},
-  className: '',
-  disabled: false,
-  disabledInput: false,
-  type: 'number',
-  width: 0,
-  min: 0,
-  max: 100,
-  step: 1,
-  size: 'normal',
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  onChange: (): void => {}
+      <Input
+        className='at-input-number__input'
+        style={inputStyle}
+        type={type}
+        value={inputValue !== null ? String(inputValue) : ''}
+        disabled={disabledInput || disabled}
+        onInput={handleInput}
+        onBlur={handleBlur}
+      />
+      <View
+        className={plusBtnCls}
+        onClick={(e: CommonEvent) => handleClick('plus', e)}
+      >
+        <Text className='at-icon at-icon-add at-input-number__btn-add'></Text>
+      </View>
+    </View>
+  )
 }
 
 AtInputNumber.propTypes = {
@@ -219,3 +197,5 @@ AtInputNumber.propTypes = {
   onBlur: PropTypes.func,
   onErrorInput: PropTypes.func
 }
+
+export default AtInputNumber

--- a/packages/taro-ui/src/components/input/index.tsx
+++ b/packages/taro-ui/src/components/input/index.tsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames'
-import PropTypes, { InferProps } from 'prop-types'
-import React from 'react'
+import PropTypes from 'prop-types'
+import React, { useRef } from 'react'
 import { Input, Label, Text, View } from '@tarojs/components'
 import { BaseEventOrig, ITouchEvent } from '@tarojs/components/types/common'
 import { InputProps } from '@tarojs/components/types/Input'
@@ -12,6 +12,7 @@ import {
   InputEventDetail,
   KeyboardHeightEventDetail
 } from '../../../types/input'
+import { noop } from '../../common/utils'
 
 type PickAtInputProps = Pick<
   AtInputProps,
@@ -45,197 +46,179 @@ function getInputProps(props: AtInputProps): GetInputPropsReturn {
   return actualProps as GetInputPropsReturn
 }
 
-export default class AtInput extends React.Component<AtInputProps> {
-  public static defaultProps: AtInputProps
-  public static propTypes: InferProps<AtInputProps>
+function AtInput(props: AtInputProps): JSX.Element {
+  const {
+    className = '',
+    customStyle = '',
+    value = '',
+    name = '',
+    placeholder = '',
+    placeholderStyle = '',
+    placeholderClass = '',
+    title = '',
+    cursorSpacing = 50,
+    confirmType = 'done',
+    selectionStart = -1,
+    selectionEnd = -1,
+    adjustPosition = true,
+    editable = true,
+    border = true,
+    error = false,
+    clear = false,
+    autoFocus = false,
+    focus = false,
+    required = false,
+    cursor,
+    onChange = noop,
+    onFocus,
+    onBlur,
+    onConfirm,
+    onErrorClick,
+    onClick,
+    onKeyboardHeightChange,
+    children
+  } = props
   // TODO: 有待考证是否为合理方式处理 #840
-  private inputClearing = false
+  const inputClearing = useRef(false)
 
-  private handleInput = (event: BaseEventOrig<InputEventDetail>): void =>
-    this.props.onChange?.(event.detail.value, event)
+  const handleInput = (event: BaseEventOrig<InputEventDetail>): void =>
+    onChange?.(event.detail.value, event)
 
-  private handleFocus = (event: BaseEventOrig<FocusEventDetail>): void => {
-    if (typeof this.props.onFocus === 'function') {
-      this.props.onFocus(event.detail.value, event)
+  const handleFocus = (event: BaseEventOrig<FocusEventDetail>): void => {
+    if (typeof onFocus === 'function') {
+      onFocus(event.detail.value, event)
     }
   }
 
-  private handleBlur = (event: BaseEventOrig<BlurEventDetail>): void => {
-    if (typeof this.props.onBlur === 'function') {
-      this.props.onBlur(event.detail.value, event)
+  const handleBlur = (event: BaseEventOrig<BlurEventDetail>): void => {
+    if (typeof onBlur === 'function') {
+      onBlur(event.detail.value, event)
     }
-    if (event.type === 'blur' && !this.inputClearing) {
+    if (event.type === 'blur' && !inputClearing.current) {
       // fix # 583 AtInput 不触发 onChange 的问题
-      this.props.onChange?.(
-        event.detail.value,
-        event as BaseEventOrig<InputEventDetail>
-      )
+      onChange?.(event.detail.value, event as BaseEventOrig<InputEventDetail>)
     }
     // 还原状态
-    this.inputClearing = false
+    inputClearing.current = false
   }
 
-  private handleConfirm = (event: BaseEventOrig<ConfirmEventDetail>): void => {
-    if (typeof this.props.onConfirm === 'function') {
-      this.props.onConfirm(event.detail.value, event)
+  const handleConfirm = (event: BaseEventOrig<ConfirmEventDetail>): void => {
+    if (typeof onConfirm === 'function') {
+      onConfirm(event.detail.value, event)
     }
   }
 
-  private handleClick = (event: ITouchEvent): void => {
-    if (!this.props.editable && typeof this.props.onClick === 'function') {
-      this.props.onClick(event)
+  const handleClick = (event: ITouchEvent): void => {
+    if (!editable && typeof onClick === 'function') {
+      onClick(event)
     }
   }
 
-  private handleClearValue = (event: ITouchEvent): void => {
-    this.inputClearing = true
-    this.props.onChange?.('', event)
+  const handleClearValue = (event: ITouchEvent): void => {
+    inputClearing.current = true
+    onChange?.('', event)
   }
 
-  private handleKeyboardHeightChange = (
+  const handleKeyboardHeightChange = (
     event: BaseEventOrig<KeyboardHeightEventDetail>
   ): void => {
-    if (typeof this.props.onKeyboardHeightChange === 'function') {
-      this.props.onKeyboardHeightChange(event)
+    if (typeof onKeyboardHeightChange === 'function') {
+      onKeyboardHeightChange(event)
     }
   }
 
-  private handleErrorClick = (event: ITouchEvent): void => {
-    if (typeof this.props.onErrorClick === 'function') {
-      this.props.onErrorClick(event)
+  const handleErrorClick = (event: ITouchEvent): void => {
+    if (typeof onErrorClick === 'function') {
+      onErrorClick(event)
     }
   }
 
-  public render(): JSX.Element {
-    const {
-      className,
-      customStyle,
-      name,
-      cursorSpacing,
-      confirmType,
-      cursor,
-      selectionStart,
-      selectionEnd,
-      adjustPosition,
-      border,
-      title,
-      error,
-      clear,
-      placeholder,
-      placeholderStyle,
-      placeholderClass,
-      autoFocus = false,
-      focus = false,
-      value,
-      required
-    } = this.props
-    const { type, maxLength, disabled, password } = getInputProps(this.props)
+  const {
+    type: inputType,
+    maxLength: inputMaxLength,
+    disabled: inputDisabled,
+    password
+  } = getInputProps({
+    ...props,
+    type: props.type ?? 'text',
+    maxlength: props.maxlength ?? 140,
+    maxLength: props.maxLength ?? 140,
+    disabled: props.disabled ?? false,
+    editable: props.editable ?? true
+  })
 
-    const rootCls = classNames(
-      'at-input',
-      {
-        'at-input--without-border': !border
-      },
-      className
-    )
-    const containerCls = classNames('at-input__container', {
-      'at-input--error': error,
-      'at-input--disabled': disabled
-    })
-    // TODO: overlayCls 是否需要移除
-    const overlayCls = classNames('at-input__overlay', {
-      'at-input__overlay--hidden': !disabled
-    })
-    const placeholderCls = classNames('placeholder', placeholderClass)
+  const rootCls = classNames(
+    'at-input',
+    {
+      'at-input--without-border': !border
+    },
+    className
+  )
+  const containerCls = classNames('at-input__container', {
+    'at-input--error': error,
+    'at-input--disabled': inputDisabled
+  })
+  // TODO: overlayCls 是否需要移除
+  const overlayCls = classNames('at-input__overlay', {
+    'at-input__overlay--hidden': !inputDisabled
+  })
+  const placeholderCls = classNames('placeholder', placeholderClass)
 
-    return (
-      <View className={rootCls} style={customStyle}>
-        <View className={containerCls}>
-          <View className={overlayCls} onClick={this.handleClick}></View>
-          {title && (
-            <Label
-              className={`at-input__title ${
-                required && 'at-input__title--required'
-              }`}
-              for={name}
-            >
-              {title}
-            </Label>
-          )}
-          <Input
-            className='at-input__input'
-            id={name}
-            name={name}
-            type={type}
-            disabled={disabled}
-            password={password}
-            placeholderStyle={placeholderStyle}
-            placeholderClass={placeholderCls}
-            placeholder={placeholder}
-            cursorSpacing={cursorSpacing}
-            maxlength={maxLength}
-            autoFocus={autoFocus}
-            // TODO: 临时解决方案，等 Taro 更新后还原到 focus={focus}
-            focus={focus}
-            value={value}
-            confirmType={confirmType}
-            cursor={cursor}
-            selectionStart={selectionStart}
-            selectionEnd={selectionEnd}
-            adjustPosition={adjustPosition}
-            onInput={this.handleInput}
-            onFocus={this.handleFocus}
-            onBlur={this.handleBlur}
-            onConfirm={this.handleConfirm}
-            onKeyboardHeightChange={this.handleKeyboardHeightChange}
-          />
-          {clear && value && (
-            <View className='at-input__icon' onTouchEnd={this.handleClearValue}>
-              <Text className='at-icon at-icon-close-circle at-input__icon-close'></Text>
-            </View>
-          )}
-          {error && (
-            <View
-              className='at-input__icon'
-              onTouchStart={this.handleErrorClick}
-            >
-              <Text className='at-icon at-icon-alert-circle at-input__icon-alert'></Text>
-            </View>
-          )}
-          <View className='at-input__children'>{this.props.children}</View>
-        </View>
+  return (
+    <View className={rootCls} style={customStyle}>
+      <View className={containerCls}>
+        <View className={overlayCls} onClick={handleClick}></View>
+        {title && (
+          <Label
+            className={`at-input__title ${
+              required && 'at-input__title--required'
+            }`}
+            for={name}
+          >
+            {title}
+          </Label>
+        )}
+        <Input
+          className='at-input__input'
+          id={name}
+          name={name}
+          type={inputType}
+          disabled={inputDisabled}
+          password={password}
+          placeholderStyle={placeholderStyle}
+          placeholderClass={placeholderCls}
+          placeholder={placeholder}
+          cursorSpacing={cursorSpacing}
+          maxlength={inputMaxLength}
+          autoFocus={autoFocus}
+          // TODO: 临时解决方案，等 Taro 更新后还原到 focus={focus}
+          focus={focus}
+          value={value}
+          confirmType={confirmType}
+          cursor={cursor}
+          selectionStart={selectionStart}
+          selectionEnd={selectionEnd}
+          adjustPosition={adjustPosition}
+          onInput={handleInput}
+          onFocus={handleFocus}
+          onBlur={handleBlur}
+          onConfirm={handleConfirm}
+          onKeyboardHeightChange={handleKeyboardHeightChange}
+        />
+        {clear && value && (
+          <View className='at-input__icon' onTouchEnd={handleClearValue}>
+            <Text className='at-icon at-icon-close-circle at-input__icon-close'></Text>
+          </View>
+        )}
+        {error && (
+          <View className='at-input__icon' onTouchStart={handleErrorClick}>
+            <Text className='at-icon at-icon-alert-circle at-input__icon-alert'></Text>
+          </View>
+        )}
+        <View className='at-input__children'>{children}</View>
       </View>
-    )
-  }
-}
-
-AtInput.defaultProps = {
-  className: '',
-  customStyle: '',
-  value: '',
-  name: '',
-  placeholder: '',
-  placeholderStyle: '',
-  placeholderClass: '',
-  title: '',
-  cursorSpacing: 50,
-  confirmType: 'done',
-  selectionStart: -1,
-  selectionEnd: -1,
-  adjustPosition: true,
-  maxlength: 140,
-  maxLength: 140,
-  type: 'text',
-  disabled: false,
-  border: true,
-  editable: true,
-  error: false,
-  clear: false,
-  autoFocus: false,
-  focus: false,
-  required: false,
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  onChange: (): void => {}
+    </View>
+  )
 }
 
 AtInput.propTypes = {
@@ -271,3 +254,5 @@ AtInput.propTypes = {
   onClick: PropTypes.func,
   required: PropTypes.bool
 }
+
+export default AtInput

--- a/packages/taro-ui/src/components/list/index.tsx
+++ b/packages/taro-ui/src/components/list/index.tsx
@@ -1,30 +1,27 @@
 import classNames from 'classnames'
-import PropTypes, { InferProps } from 'prop-types'
+import PropTypes from 'prop-types'
 import React from 'react'
 import { View } from '@tarojs/components'
 import { AtListProps } from '../../../types/list'
 
-export default class AtList extends React.Component<AtListProps> {
-  public static defaultProps: AtListProps
-  public static propTypes: InferProps<AtListProps>
+function AtList({
+  hasBorder = true,
+  className,
+  children
+}: AtListProps): JSX.Element {
+  const rootClass = classNames(
+    'at-list',
+    {
+      'at-list--no-border': !hasBorder
+    },
+    className
+  )
 
-  public render(): JSX.Element {
-    const rootClass = classNames(
-      'at-list',
-      {
-        'at-list--no-border': !this.props.hasBorder
-      },
-      this.props.className
-    )
-
-    return <View className={rootClass}>{this.props.children}</View>
-  }
-}
-
-AtList.defaultProps = {
-  hasBorder: true
+  return <View className={rootClass}>{children}</View>
 }
 
 AtList.propTypes = {
   hasBorder: PropTypes.bool
 }
+
+export default AtList

--- a/packages/taro-ui/src/components/list/item/index.tsx
+++ b/packages/taro-ui/src/components/list/item/index.tsx
@@ -1,165 +1,137 @@
 import classNames from 'classnames'
-import PropTypes, { InferProps } from 'prop-types'
+import PropTypes from 'prop-types'
 import React from 'react'
 import { Image, Switch, Text, View } from '@tarojs/components'
 import { CommonEvent, ITouchEvent } from '@tarojs/components/types/common'
 import { AtListItemProps } from '../../../../types/list'
 import { mergeStyle } from '../../../common/utils'
 
-export default class AtListItem extends React.Component<AtListItemProps> {
-  public static defaultProps: AtListItemProps
-  public static propTypes: InferProps<AtListItemProps>
-
-  private handleClick = (event: ITouchEvent): void => {
-    if (typeof this.props.onClick === 'function' && !this.props.disabled) {
-      this.props.onClick(event)
+function AtListItem({
+  note = '',
+  disabled = false,
+  title = '',
+  thumb = '',
+  isSwitch = false,
+  hasBorder = true,
+  switchColor = '#6190E8',
+  switchIsCheck = false,
+  extraText = '',
+  extraThumb = '',
+  iconInfo = { value: '' },
+  arrow,
+  icon,
+  className,
+  onClick,
+  onSwitchChange
+}: AtListItemProps): JSX.Element {
+  const handleClick = (event: ITouchEvent): void => {
+    if (typeof onClick === 'function' && !disabled) {
+      onClick(event)
     }
   }
 
-  private handleSwitchClick(e: CommonEvent): void {
+  const handleSwitchClick = (e: CommonEvent): void => {
     e.stopPropagation()
   }
 
-  private handleSwitchChange = (event: CommonEvent): void => {
-    if (
-      typeof this.props.onSwitchChange === 'function' &&
-      !this.props.disabled
-    ) {
-      this.props.onSwitchChange(event)
+  const handleSwitchChange = (event: CommonEvent): void => {
+    if (typeof onSwitchChange === 'function' && !disabled) {
+      onSwitchChange(event)
     }
   }
 
-  public render(): JSX.Element {
-    const {
-      note,
-      arrow,
-      thumb,
-      iconInfo,
-      disabled,
-      isSwitch,
-      hasBorder,
-      extraThumb,
-      switchColor,
-      switchIsCheck,
-      icon
-    } = this.props
+  const rootClass = classNames(
+    'at-list__item',
+    {
+      'at-list__item--thumb': thumb,
+      'at-list__item--multiple': note,
+      'at-list__item--disabled': disabled,
+      'at-list__item--no-border': !hasBorder
+    },
+    className
+  )
 
-    const { extraText, title } = this.props
-
-    const rootClass = classNames(
-      'at-list__item',
-      {
-        'at-list__item--thumb': thumb,
-        'at-list__item--multiple': note,
-        'at-list__item--disabled': disabled,
-        'at-list__item--no-border': !hasBorder
-      },
-      this.props.className
-    )
-
-    const renderIcon = () => {
-      if (icon) {
-        return <View className='item-icon'>{icon}</View>
-      } else if (iconInfo?.value) {
-        const iconClass = classNames(
-          (iconInfo && iconInfo.prefixClass) || 'at-icon',
-          {
-            [`${(iconInfo && iconInfo.prefixClass) || 'at-icon'}-${
-              iconInfo && iconInfo.value
-            }`]: iconInfo && iconInfo.value
-          },
-          iconInfo && iconInfo.className
-        )
-        return (
-          <View className='at-list__item-icon item-icon'>
-            <Text
-              className={iconClass}
-              style={mergeStyle(
-                {
-                  color: iconInfo.color || '',
-                  fontSize: `${iconInfo.size || 24}px`
-                },
-                iconInfo.customStyle || ''
-              )}
-            ></Text>
-          </View>
-        )
-      } else if (thumb) {
-        return (
-          <View className='at-list__item-thumb item-thumb'>
-            <Image
-              className='item-thumb__info'
-              mode='scaleToFill'
-              src={thumb}
-            />
-          </View>
-        )
-      }
+  const renderIcon = () => {
+    if (icon) {
+      return <View className='item-icon'>{icon}</View>
+    } else if (iconInfo?.value) {
+      const iconClass = classNames(
+        (iconInfo && iconInfo.prefixClass) || 'at-icon',
+        {
+          [`${(iconInfo && iconInfo.prefixClass) || 'at-icon'}-${
+            iconInfo && iconInfo.value
+          }`]: iconInfo && iconInfo.value
+        },
+        iconInfo && iconInfo.className
+      )
+      return (
+        <View className='at-list__item-icon item-icon'>
+          <Text
+            className={iconClass}
+            style={mergeStyle(
+              {
+                color: iconInfo.color || '',
+                fontSize: `${iconInfo.size || 24}px`
+              },
+              iconInfo.customStyle || ''
+            )}
+          ></Text>
+        </View>
+      )
+    } else if (thumb) {
+      return (
+        <View className='at-list__item-thumb item-thumb'>
+          <Image className='item-thumb__info' mode='scaleToFill' src={thumb} />
+        </View>
+      )
     }
+  }
 
-    return (
-      <View className={rootClass} onClick={this.handleClick}>
-        <View className='at-list__item-container'>
-          {renderIcon()}
-          <View className='at-list__item-content item-content'>
-            <View className='item-content__info'>
-              <View className='item-content__info-title'>{title}</View>
-              {note && <View className='item-content__info-note'>{note}</View>}
-            </View>
-          </View>
-          <View className='at-list__item-extra item-extra'>
-            {extraText && <View className='item-extra__info'>{extraText}</View>}
-
-            {extraThumb && !extraText && (
-              <View className='item-extra__image'>
-                <Image
-                  className='item-extra__image-info'
-                  mode='aspectFit'
-                  src={extraThumb}
-                />
-              </View>
-            )}
-
-            {isSwitch && !extraThumb && !extraText && (
-              <View
-                className='item-extra__switch'
-                onClick={this.handleSwitchClick}
-              >
-                <Switch
-                  color={switchColor}
-                  disabled={disabled}
-                  checked={switchIsCheck}
-                  onChange={this.handleSwitchChange}
-                />
-              </View>
-            )}
-
-            {arrow ? (
-              <View className='item-extra__icon'>
-                <Text
-                  className={`at-icon item-extra__icon-arrow at-icon-chevron-${arrow}`}
-                />
-              </View>
-            ) : null}
+  return (
+    <View className={rootClass} onClick={handleClick}>
+      <View className='at-list__item-container'>
+        {renderIcon()}
+        <View className='at-list__item-content item-content'>
+          <View className='item-content__info'>
+            <View className='item-content__info-title'>{title}</View>
+            {note && <View className='item-content__info-note'>{note}</View>}
           </View>
         </View>
-      </View>
-    )
-  }
-}
+        <View className='at-list__item-extra item-extra'>
+          {extraText && <View className='item-extra__info'>{extraText}</View>}
 
-AtListItem.defaultProps = {
-  note: '',
-  disabled: false,
-  title: '',
-  thumb: '',
-  isSwitch: false,
-  hasBorder: true,
-  switchColor: '#6190E8',
-  switchIsCheck: false,
-  extraText: '',
-  extraThumb: '',
-  iconInfo: { value: '' }
+          {extraThumb && !extraText && (
+            <View className='item-extra__image'>
+              <Image
+                className='item-extra__image-info'
+                mode='aspectFit'
+                src={extraThumb}
+              />
+            </View>
+          )}
+
+          {isSwitch && !extraThumb && !extraText && (
+            <View className='item-extra__switch' onClick={handleSwitchClick}>
+              <Switch
+                color={switchColor}
+                disabled={disabled}
+                checked={switchIsCheck}
+                onChange={handleSwitchChange}
+              />
+            </View>
+          )}
+
+          {arrow ? (
+            <View className='item-extra__icon'>
+              <Text
+                className={`at-icon item-extra__icon-arrow at-icon-chevron-${arrow}`}
+              />
+            </View>
+          ) : null}
+        </View>
+      </View>
+    </View>
+  )
 }
 
 AtListItem.propTypes = {
@@ -185,3 +157,5 @@ AtListItem.propTypes = {
     className: PropTypes.oneOfType([PropTypes.array, PropTypes.string])
   })
 }
+
+export default AtListItem

--- a/packages/taro-ui/src/components/load-more/index.tsx
+++ b/packages/taro-ui/src/components/load-more/index.tsx
@@ -2,6 +2,7 @@ import classNames from 'classnames'
 import PropTypes from 'prop-types'
 import React from 'react'
 import { Text, View } from '@tarojs/components'
+import { CommonEvent } from '@tarojs/components/types/common'
 import { AtLoadMoreProps } from '../../../types/load-more'
 import AtActivityIndicator from '../activity-indicator/index'
 import AtButton from '../button/index'
@@ -17,8 +18,8 @@ function AtLoadMore({
   noMoreText = '没有更多',
   onClick
 }: AtLoadMoreProps): JSX.Element {
-  const handleClick = (): void => {
-    onClick && onClick(arguments as any)
+  const handleClick = (event: CommonEvent): void => {
+    onClick && onClick(event)
   }
 
   let component: JSX.Element | null = null

--- a/packages/taro-ui/src/components/load-more/index.tsx
+++ b/packages/taro-ui/src/components/load-more/index.tsx
@@ -1,74 +1,50 @@
 import classNames from 'classnames'
-import PropTypes, { InferProps } from 'prop-types'
+import PropTypes from 'prop-types'
 import React from 'react'
 import { Text, View } from '@tarojs/components'
 import { AtLoadMoreProps } from '../../../types/load-more'
 import AtActivityIndicator from '../activity-indicator/index'
 import AtButton from '../button/index'
 
-export default class AtLoadMore extends React.Component<AtLoadMoreProps> {
-  public static defaultProps: AtLoadMoreProps
-  public static propTypes: InferProps<AtLoadMoreProps>
-
-  private onClick(): void {
-    this.props.onClick && this.props.onClick(arguments as any)
+function AtLoadMore({
+  className = '',
+  customStyle = '',
+  loadingText = '加载中',
+  moreText = '查看更多',
+  status = 'more',
+  moreBtnStyle = '',
+  noMoreTextStyle = '',
+  noMoreText = '没有更多',
+  onClick
+}: AtLoadMoreProps): JSX.Element {
+  const handleClick = (): void => {
+    onClick && onClick(arguments as any)
   }
 
-  public render(): JSX.Element {
-    const {
-      className,
-      customStyle,
-      loadingText,
-      moreText,
-      status,
-      moreBtnStyle,
-      noMoreTextStyle,
-      noMoreText
-    } = this.props
-
-    let component: JSX.Element | null = null
-    if (status === 'loading') {
-      component = <AtActivityIndicator mode='center' content={loadingText} />
-    } else if (status === 'more') {
-      component = (
-        <View className='at-load-more__cnt'>
-          <AtButton
-            full
-            onClick={this.onClick.bind(this)}
-            customStyle={moreBtnStyle}
-          >
-            {moreText}
-          </AtButton>
-        </View>
-      )
-    } else {
-      component = (
-        <Text className='at-load-more__tip' style={noMoreTextStyle}>
-          {noMoreText}
-        </Text>
-      )
-    }
-
-    return (
-      <View
-        className={classNames('at-load-more', className)}
-        style={customStyle}
-      >
-        {component}
+  let component: JSX.Element | null = null
+  if (status === 'loading') {
+    component = <AtActivityIndicator mode='center' content={loadingText} />
+  } else if (status === 'more') {
+    component = (
+      <View className='at-load-more__cnt'>
+        <AtButton full onClick={handleClick} customStyle={moreBtnStyle}>
+          {moreText}
+        </AtButton>
       </View>
     )
+  } else {
+    component = (
+      <Text className='at-load-more__tip' style={noMoreTextStyle}>
+        {noMoreText}
+      </Text>
+    )
   }
-}
 
-AtLoadMore.defaultProps = {
-  customStyle: '',
-  className: '',
-  noMoreTextStyle: '',
-  moreBtnStyle: '',
-  status: 'more',
-  loadingText: '加载中',
-  moreText: '查看更多',
-  noMoreText: '没有更多'
+  return (
+    <View className={classNames('at-load-more', className)} style={customStyle}>
+      {component}
+    </View>
+  )
 }
 
 AtLoadMore.propTypes = {
@@ -82,3 +58,5 @@ AtLoadMore.propTypes = {
   noMoreText: PropTypes.string,
   onClick: PropTypes.func
 }
+
+export default AtLoadMore

--- a/packages/taro-ui/src/components/loading/index.tsx
+++ b/packages/taro-ui/src/components/loading/index.tsx
@@ -1,4 +1,4 @@
-import PropTypes, { InferProps } from 'prop-types'
+import PropTypes from 'prop-types'
 import React from 'react'
 import { View } from '@tarojs/components'
 import { pxTransform } from '../../common/utils'
@@ -8,39 +8,30 @@ interface AtLoadingProps {
   color?: string | number
 }
 
-export default class AtLoading extends React.Component<AtLoadingProps> {
-  public static defaultProps: AtLoadingProps
-  public static propTypes: InferProps<AtLoadingProps>
-
-  public render(): JSX.Element {
-    const { color, size } = this.props
-    const loadingSize = typeof size === 'string' ? size : String(size)
-    const sizeStyle = {
-      width: size ? `${pxTransform(parseInt(loadingSize))}` : '',
-      height: size ? `${pxTransform(parseInt(loadingSize))}` : ''
-    }
-    const colorStyle = {
-      border: color ? `1px solid ${color}` : '',
-      borderColor: color ? `${color} transparent transparent transparent` : ''
-    }
-    const ringStyle = Object.assign({}, colorStyle, sizeStyle)
-
-    return (
-      <View className='at-loading' style={sizeStyle}>
-        <View className='at-loading__ring' style={ringStyle}></View>
-        <View className='at-loading__ring' style={ringStyle}></View>
-        <View className='at-loading__ring' style={ringStyle}></View>
-      </View>
-    )
+function AtLoading({ color = '', size = 0 }: AtLoadingProps): JSX.Element {
+  const loadingSize = typeof size === 'string' ? size : String(size)
+  const sizeStyle = {
+    width: size ? `${pxTransform(parseInt(loadingSize))}` : '',
+    height: size ? `${pxTransform(parseInt(loadingSize))}` : ''
   }
-}
+  const colorStyle = {
+    border: color ? `1px solid ${color}` : '',
+    borderColor: color ? `${color} transparent transparent transparent` : ''
+  }
+  const ringStyle = Object.assign({}, colorStyle, sizeStyle)
 
-AtLoading.defaultProps = {
-  size: 0,
-  color: ''
+  return (
+    <View className='at-loading' style={sizeStyle}>
+      <View className='at-loading__ring' style={ringStyle}></View>
+      <View className='at-loading__ring' style={ringStyle}></View>
+      <View className='at-loading__ring' style={ringStyle}></View>
+    </View>
+  )
 }
 
 AtLoading.propTypes = {
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   color: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
 }
+
+export default AtLoading

--- a/packages/taro-ui/src/components/message/index.tsx
+++ b/packages/taro-ui/src/components/message/index.tsx
@@ -1,98 +1,74 @@
 import classNames from 'classnames'
-import PropTypes, { InferProps } from 'prop-types'
-import React from 'react'
+import PropTypes from 'prop-types'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { View } from '@tarojs/components'
-import Taro from '@tarojs/taro'
-import { AtMessageProps, AtMessageState } from '../../../types/message'
+import Taro, { useDidHide, useDidShow } from '@tarojs/taro'
+import { AtMessageProps } from '../../../types/message'
 
-export default class AtMessage extends React.Component<
-  AtMessageProps,
-  AtMessageState
-> {
-  public static defaultProps: AtMessageProps
-  public static propTypes: InferProps<AtMessageProps>
+function AtMessage({
+  customStyle = '',
+  className = ''
+}: AtMessageProps): JSX.Element {
+  const [_isOpened, setIsOpened] = useState(false)
+  const [_message, setMessage] = useState('')
+  const [_type, setType] = useState('info')
+  const durationRef = useRef(3000)
+  const timerRef = useRef<NodeJS.Timeout | number | null>(null)
 
-  private _timer: NodeJS.Timeout | number | null
-
-  public constructor(props: AtMessageProps) {
-    super(props)
-    this.state = {
-      _isOpened: false,
-      _message: '',
-      _type: 'info',
-      _duration: 3000
-    }
-    this._timer = null
-  }
-
-  private bindMessageListener(): void {
+  const bindMessageListener = useCallback((): void => {
     Taro.eventCenter.on('atMessage', (options = {}) => {
       const { message, type, duration } = options
-      const newState = {
-        _isOpened: true,
-        _message: message,
-        _type: type,
-        _duration: duration || this.state._duration
-      }
-      this.setState(newState, () => {
-        clearTimeout(this._timer as number)
-        this._timer = setTimeout(() => {
-          this.setState({
-            _isOpened: false
-          })
-        }, this.state._duration)
-      })
+      const newDuration = duration || durationRef.current
+      durationRef.current = newDuration
+      setIsOpened(true)
+      setMessage(message)
+      setType(type)
+      clearTimeout(timerRef.current as number)
+      timerRef.current = setTimeout(() => {
+        setIsOpened(false)
+      }, newDuration)
     })
-    // 绑定函数
     Taro.atMessage = Taro.eventCenter.trigger.bind(
       Taro.eventCenter,
       'atMessage'
     )
-  }
+  }, [])
 
-  public componentDidShow(): void {
-    this.bindMessageListener()
-  }
+  useEffect(() => {
+    bindMessageListener()
+    return () => {
+      Taro.eventCenter.off('atMessage')
+    }
+  }, [bindMessageListener])
 
-  public componentDidMount(): void {
-    this.bindMessageListener()
-  }
+  useDidShow(() => {
+    bindMessageListener()
+  })
 
-  public componentDidHide(): void {
+  useDidHide(() => {
     Taro.eventCenter.off('atMessage')
-  }
+  })
 
-  public componentWillUnmount(): void {
-    Taro.eventCenter.off('atMessage')
-  }
+  const rootCls = classNames(
+    {
+      'at-message': true,
+      'at-message--show': _isOpened,
+      'at-message--hidden': !_isOpened
+    },
+    `at-message--${_type}`,
+    className
+  )
 
-  public render(): JSX.Element {
-    const { className, customStyle } = this.props
-    const { _message, _isOpened, _type } = this.state
-    const rootCls = classNames(
-      {
-        'at-message': true,
-        'at-message--show': _isOpened,
-        'at-message--hidden': !_isOpened
-      },
-      `at-message--${_type}`,
-      className
-    )
-
-    return (
-      <View className={rootCls} style={customStyle}>
-        {_message}
-      </View>
-    )
-  }
-}
-
-AtMessage.defaultProps = {
-  customStyle: '',
-  className: ''
+  return (
+    <View className={rootCls} style={customStyle}>
+      {_message}
+    </View>
+  )
 }
 
 AtMessage.propTypes = {
   customStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
   className: PropTypes.oneOfType([PropTypes.array, PropTypes.string])
 }
+
+export default AtMessage

--- a/packages/taro-ui/src/components/modal/action/index.tsx
+++ b/packages/taro-ui/src/components/modal/action/index.tsx
@@ -1,34 +1,31 @@
 import classNames from 'classnames'
-import PropTypes, { InferProps } from 'prop-types'
+import PropTypes from 'prop-types'
 import React from 'react'
 import { View } from '@tarojs/components'
 import { AtModalActionProps } from '../../../../types/modal'
 
-export default class AtModalAction extends React.Component<AtModalActionProps> {
-  public static defaultProps: AtModalActionProps
-  public static propTypes: InferProps<AtModalActionProps>
+function AtModalAction({
+  isSimple = false,
+  className,
+  children
+}: AtModalActionProps): JSX.Element {
+  const rootClass = classNames(
+    'at-modal__footer',
+    {
+      'at-modal__footer--simple': isSimple
+    },
+    className
+  )
 
-  public render(): JSX.Element {
-    const rootClass = classNames(
-      'at-modal__footer',
-      {
-        'at-modal__footer--simple': this.props.isSimple
-      },
-      this.props.className
-    )
-
-    return (
-      <View className={rootClass}>
-        <View className='at-modal__action'>{this.props.children}</View>
-      </View>
-    )
-  }
-}
-
-AtModalAction.defaultProps = {
-  isSimple: false
+  return (
+    <View className={rootClass}>
+      <View className='at-modal__action'>{children}</View>
+    </View>
+  )
 }
 
 AtModalAction.propTypes = {
   isSimple: PropTypes.bool
 }
+
+export default AtModalAction

--- a/packages/taro-ui/src/components/modal/content/index.tsx
+++ b/packages/taro-ui/src/components/modal/content/index.tsx
@@ -3,13 +3,16 @@ import React from 'react'
 import { ScrollView } from '@tarojs/components'
 import { AtModalContentProps } from '../../../../types/modal'
 
-export default class AtModalContent extends React.Component<AtModalContentProps> {
-  public render(): JSX.Element {
-    const rootClass = classNames('at-modal__content', this.props.className)
-    return (
-      <ScrollView scrollY className={rootClass}>
-        {this.props.children}
-      </ScrollView>
-    )
-  }
+function AtModalContent({
+  className,
+  children
+}: AtModalContentProps): JSX.Element {
+  const rootClass = classNames('at-modal__content', className)
+  return (
+    <ScrollView scrollY className={rootClass}>
+      {children}
+    </ScrollView>
+  )
 }
+
+export default AtModalContent

--- a/packages/taro-ui/src/components/modal/header/index.tsx
+++ b/packages/taro-ui/src/components/modal/header/index.tsx
@@ -3,9 +3,12 @@ import React from 'react'
 import { View } from '@tarojs/components'
 import { AtModalHeaderProps } from '../../../../types/modal'
 
-export default class AtModalHeader extends React.Component<AtModalHeaderProps> {
-  public render(): JSX.Element {
-    const rootClass = classNames('at-modal__header', this.props.className)
-    return <View className={rootClass}>{this.props.children}</View>
-  }
+function AtModalHeader({
+  className,
+  children
+}: AtModalHeaderProps): JSX.Element {
+  const rootClass = classNames('at-modal__header', className)
+  return <View className={rootClass}>{children}</View>
 }
+
+export default AtModalHeader

--- a/packages/taro-ui/src/components/modal/index.tsx
+++ b/packages/taro-ui/src/components/modal/index.tsx
@@ -1,146 +1,125 @@
 import classNames from 'classnames'
-import PropTypes, { InferProps } from 'prop-types'
-import React from 'react'
+import PropTypes from 'prop-types'
+import React, { useEffect, useRef, useState } from 'react'
 import { Button, Text, View } from '@tarojs/components'
 import { CommonEvent } from '@tarojs/components/types/common'
 import Taro from '@tarojs/taro'
-import { AtModalProps, AtModalState } from '../../../types/modal'
+import { AtModalProps } from '../../../types/modal'
 import { handleTouchScroll } from '../../common/utils'
 import AtModalAction from './action/index'
 import AtModalContent from './content/index'
 import AtModalHeader from './header/index'
 
-export default class AtModal extends React.Component<
-  AtModalProps,
-  AtModalState
-> {
-  public static defaultProps: AtModalProps
-  public static propTypes: InferProps<AtModalProps>
+function AtModal({
+  isOpened = false,
+  closeOnClickOverlay = true,
+  title,
+  content,
+  cancelText,
+  confirmText,
+  className,
+  children,
+  onClose,
+  onCancel,
+  onConfirm
+}: AtModalProps): JSX.Element {
+  const [_isOpened, setIsOpened] = useState(isOpened)
+  const prevIsOpenedPropRef = useRef(isOpened)
+  const isWEB = Taro.getEnv() === Taro.ENV_TYPE.WEB
 
-  public constructor(props: AtModalProps) {
-    super(props)
-    const { isOpened } = props
-    this.state = {
-      _isOpened: isOpened,
-      isWEB: Taro.getEnv() === Taro.ENV_TYPE.WEB
-    }
-  }
-
-  public UNSAFE_componentWillReceiveProps(nextProps: AtModalProps): void {
-    const { isOpened } = nextProps
-
-    if (this.props.isOpened !== isOpened) {
+  useEffect(() => {
+    if (prevIsOpenedPropRef.current !== isOpened) {
       handleTouchScroll(isOpened)
+      prevIsOpenedPropRef.current = isOpened
     }
+    setIsOpened(prev => (isOpened !== prev ? isOpened : prev))
+  }, [isOpened])
 
-    if (isOpened !== this.state._isOpened) {
-      this.setState({
-        _isOpened: isOpened
-      })
-    }
-  }
-
-  private handleClickOverlay = (): void => {
-    if (this.props.closeOnClickOverlay) {
-      this.setState(
-        {
-          _isOpened: false
-        },
-        this.handleClose
-      )
-    }
-  }
-
-  private handleClose = (event?: CommonEvent): void => {
-    if (typeof this.props.onClose === 'function') {
+  const handleClose = (event?: CommonEvent): void => {
+    if (typeof onClose === 'function') {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      this.props.onClose(event!)
+      onClose(event!)
     }
   }
 
-  private handleCancel = (event: CommonEvent): void => {
-    if (typeof this.props.onCancel === 'function') {
-      this.props.onCancel(event)
+  const handleClickOverlay = (): void => {
+    if (closeOnClickOverlay) {
+      setIsOpened(false)
+      handleClose()
     }
   }
 
-  private handleConfirm = (event: CommonEvent): void => {
-    if (typeof this.props.onConfirm === 'function') {
-      this.props.onConfirm(event)
+  const handleCancel = (event: CommonEvent): void => {
+    if (typeof onCancel === 'function') {
+      onCancel(event)
     }
   }
 
-  private handleTouchMove = (e: CommonEvent): void => {
+  const handleConfirm = (event: CommonEvent): void => {
+    if (typeof onConfirm === 'function') {
+      onConfirm(event)
+    }
+  }
+
+  const handleTouchMove = (e: CommonEvent): void => {
     e.stopPropagation()
   }
 
-  public render(): JSX.Element {
-    const { _isOpened, isWEB } = this.state
-    const { title, content, cancelText, confirmText } = this.props
-    const rootClass = classNames(
-      'at-modal',
-      {
-        'at-modal--active': _isOpened
-      },
-      this.props.className
-    )
+  const rootClass = classNames(
+    'at-modal',
+    {
+      'at-modal--active': _isOpened
+    },
+    className
+  )
 
-    if (title || content) {
-      const isRenderAction = cancelText || confirmText
-      return (
-        <View className={rootClass}>
-          <View
-            onClick={this.handleClickOverlay}
-            className='at-modal__overlay'
-          />
-          <View className='at-modal__container'>
-            {title && (
-              <AtModalHeader>
-                <Text>{title}</Text>
-              </AtModalHeader>
-            )}
-            {content && (
-              <AtModalContent>
-                <View className='content-simple'>
-                  {isWEB ? (
-                    <Text
-                      dangerouslySetInnerHTML={{
-                        __html: content.replace(/\\n/g, '<br/>')
-                      }}
-                    ></Text>
-                  ) : (
-                    <Text>{content}</Text>
-                  )}
-                </View>
-              </AtModalContent>
-            )}
-            {isRenderAction && (
-              <AtModalAction isSimple>
-                {cancelText && (
-                  <Button onClick={this.handleCancel}>{cancelText}</Button>
-                )}
-                {confirmText && (
-                  <Button onClick={this.handleConfirm}>{confirmText}</Button>
-                )}
-              </AtModalAction>
-            )}
-          </View>
-        </View>
-      )
-    }
-
+  if (title || content) {
+    const isRenderAction = cancelText || confirmText
     return (
-      <View onTouchMove={this.handleTouchMove} className={rootClass}>
-        <View className='at-modal__overlay' onClick={this.handleClickOverlay} />
-        <View className='at-modal__container'>{this.props.children}</View>
+      <View className={rootClass}>
+        <View onClick={handleClickOverlay} className='at-modal__overlay' />
+        <View className='at-modal__container'>
+          {title && (
+            <AtModalHeader>
+              <Text>{title}</Text>
+            </AtModalHeader>
+          )}
+          {content && (
+            <AtModalContent>
+              <View className='content-simple'>
+                {isWEB ? (
+                  <Text
+                    dangerouslySetInnerHTML={{
+                      __html: content.replace(/\\n/g, '<br/>')
+                    }}
+                  ></Text>
+                ) : (
+                  <Text>{content}</Text>
+                )}
+              </View>
+            </AtModalContent>
+          )}
+          {isRenderAction && (
+            <AtModalAction isSimple>
+              {cancelText && (
+                <Button onClick={handleCancel}>{cancelText}</Button>
+              )}
+              {confirmText && (
+                <Button onClick={handleConfirm}>{confirmText}</Button>
+              )}
+            </AtModalAction>
+          )}
+        </View>
       </View>
     )
   }
-}
 
-AtModal.defaultProps = {
-  isOpened: false,
-  closeOnClickOverlay: true
+  return (
+    <View onTouchMove={handleTouchMove} className={rootClass}>
+      <View className='at-modal__overlay' onClick={handleClickOverlay} />
+      <View className='at-modal__container'>{children}</View>
+    </View>
+  )
 }
 
 AtModal.propTypes = {
@@ -154,3 +133,5 @@ AtModal.propTypes = {
   cancelText: PropTypes.string,
   confirmText: PropTypes.string
 }
+
+export default AtModal

--- a/packages/taro-ui/src/components/nav-bar/index.tsx
+++ b/packages/taro-ui/src/components/nav-bar/index.tsx
@@ -1,197 +1,179 @@
 import classNames from 'classnames'
-import PropTypes, { InferProps } from 'prop-types'
+import PropTypes from 'prop-types'
 import React from 'react'
 import { Text, View } from '@tarojs/components'
 import { ITouchEvent } from '@tarojs/components/types/common'
 import { AtNavBarProps } from '../../../types/nav-bar'
 import { mergeStyle, pxTransform } from '../../common/utils'
 
-export default class AtNavBar extends React.Component<AtNavBarProps> {
-  public static defaultProps: AtNavBarProps
-  public static propTypes: InferProps<AtNavBarProps>
-
-  private handleClickLeftView(event: ITouchEvent): void {
-    this.props.onClickLeftIcon && this.props.onClickLeftIcon(event)
+function AtNavBar({
+  customStyle = '',
+  className = '',
+  fixed = false,
+  border = true,
+  color = '',
+  leftIconType = '',
+  leftText = '',
+  title = '',
+  rightFirstIconType = '',
+  rightSecondIconType = '',
+  children,
+  onClickLeftIcon,
+  onClickRgIconSt,
+  onClickRgIconNd,
+  onClickTitle
+}: AtNavBarProps): JSX.Element {
+  const handleClickLeftView = (event: ITouchEvent): void => {
+    onClickLeftIcon && onClickLeftIcon(event)
   }
 
-  private handleClickSt(event: ITouchEvent): void {
-    this.props.onClickRgIconSt && this.props.onClickRgIconSt(event)
+  const handleClickSt = (event: ITouchEvent): void => {
+    onClickRgIconSt && onClickRgIconSt(event)
   }
 
-  private handleClickNd(event: ITouchEvent): void {
-    this.props.onClickRgIconNd && this.props.onClickRgIconNd(event)
+  const handleClickNd = (event: ITouchEvent): void => {
+    onClickRgIconNd && onClickRgIconNd(event)
   }
 
-  private handleClickTitle(event: ITouchEvent): void {
-    this.props.onClickTitle && this.props.onClickTitle(event)
+  const handleClickTitle = (event: ITouchEvent): void => {
+    onClickTitle && onClickTitle(event)
   }
 
-  public render(): JSX.Element {
-    const {
-      customStyle,
-      className,
-      color,
-      fixed,
-      border,
-      leftIconType,
-      leftText,
-      title,
-      rightFirstIconType,
-      rightSecondIconType
-    } = this.props
-    const linkStyle = { color }
+  const linkStyle = { color }
 
-    const defaultIconInfo = {
-      customStyle: '',
-      className: '',
-      prefixClass: 'at-icon',
-      value: '',
-      color: '',
-      size: 24
-    }
+  const defaultIconInfo = {
+    customStyle: '',
+    className: '',
+    prefixClass: 'at-icon',
+    value: '',
+    color: '',
+    size: 24
+  }
 
-    const leftIconInfo =
-      leftIconType instanceof Object
-        ? { ...defaultIconInfo, ...leftIconType }
-        : { ...defaultIconInfo, value: leftIconType }
-    const leftIconClass = classNames(
-      leftIconInfo.prefixClass,
-      {
-        [`${leftIconInfo.prefixClass}-${leftIconInfo.value}`]:
-          leftIconInfo.value
-      },
-      leftIconInfo.className
-    )
+  const leftIconInfo =
+    leftIconType instanceof Object
+      ? { ...defaultIconInfo, ...leftIconType }
+      : { ...defaultIconInfo, value: leftIconType }
+  const leftIconClass = classNames(
+    leftIconInfo.prefixClass,
+    {
+      [`${leftIconInfo.prefixClass}-${leftIconInfo.value}`]: leftIconInfo.value
+    },
+    leftIconInfo.className
+  )
 
-    const rightFirstIconInfo =
-      rightFirstIconType instanceof Object
-        ? { ...defaultIconInfo, ...rightFirstIconType }
-        : { ...defaultIconInfo, value: rightFirstIconType }
-    const rightFirstIconClass = classNames(
-      rightFirstIconInfo.prefixClass,
-      {
-        [`${rightFirstIconInfo.prefixClass}-${rightFirstIconInfo.value}`]:
-          rightFirstIconInfo.value
-      },
-      rightFirstIconInfo.className
-    )
+  const rightFirstIconInfo =
+    rightFirstIconType instanceof Object
+      ? { ...defaultIconInfo, ...rightFirstIconType }
+      : { ...defaultIconInfo, value: rightFirstIconType }
+  const rightFirstIconClass = classNames(
+    rightFirstIconInfo.prefixClass,
+    {
+      [`${rightFirstIconInfo.prefixClass}-${rightFirstIconInfo.value}`]:
+        rightFirstIconInfo.value
+    },
+    rightFirstIconInfo.className
+  )
 
-    const rightSecondIconInfo =
-      rightSecondIconType instanceof Object
-        ? { ...defaultIconInfo, ...rightSecondIconType }
-        : { ...defaultIconInfo, value: rightSecondIconType }
-    const rightSecondIconClass = classNames(
-      rightSecondIconInfo.prefixClass,
-      {
-        [`${rightSecondIconInfo.prefixClass}-${rightSecondIconInfo.value}`]:
-          rightSecondIconInfo.value
-      },
-      rightSecondIconInfo.className
-    )
+  const rightSecondIconInfo =
+    rightSecondIconType instanceof Object
+      ? { ...defaultIconInfo, ...rightSecondIconType }
+      : { ...defaultIconInfo, value: rightSecondIconType }
+  const rightSecondIconClass = classNames(
+    rightSecondIconInfo.prefixClass,
+    {
+      [`${rightSecondIconInfo.prefixClass}-${rightSecondIconInfo.value}`]:
+        rightSecondIconInfo.value
+    },
+    rightSecondIconInfo.className
+  )
 
-    return (
+  return (
+    <View
+      className={classNames(
+        {
+          'at-nav-bar': true,
+          'at-nav-bar--fixed': fixed,
+          'at-nav-bar--no-border': !border
+        },
+        className
+      )}
+      style={customStyle}
+    >
       <View
-        className={classNames(
-          {
-            'at-nav-bar': true,
-            'at-nav-bar--fixed': fixed,
-            'at-nav-bar--no-border': !border
-          },
-          className
-        )}
-        style={customStyle}
+        className='at-nav-bar__left-view'
+        onClick={handleClickLeftView}
+        style={linkStyle}
       >
+        {leftIconType && (
+          <Text
+            className={leftIconClass}
+            style={mergeStyle(
+              {
+                color: leftIconInfo.color,
+                fontSize: `${pxTransform(
+                  parseInt(leftIconInfo.size.toString()) * 2
+                )}`
+              },
+              leftIconInfo.customStyle
+            )}
+          ></Text>
+        )}
+        <Text className='at-nav-bar__text'>{leftText}</Text>
+      </View>
+      <View className='at-nav-bar__title' onClick={handleClickTitle}>
+        {title || children}
+      </View>
+      <View className='at-nav-bar__right-view'>
         <View
-          className='at-nav-bar__left-view'
-          onClick={this.handleClickLeftView.bind(this)}
+          className={classNames({
+            'at-nav-bar__container': true,
+            'at-nav-bar__container--hide': !rightSecondIconType
+          })}
           style={linkStyle}
+          onClick={handleClickNd}
         >
-          {leftIconType && (
+          {rightSecondIconType && (
             <Text
-              className={leftIconClass}
+              className={rightSecondIconClass}
               style={mergeStyle(
                 {
-                  color: leftIconInfo.color,
+                  color: rightSecondIconInfo.color,
                   fontSize: `${pxTransform(
-                    parseInt(leftIconInfo.size.toString()) * 2
+                    parseInt(rightSecondIconInfo.size.toString()) * 2
                   )}`
                 },
-                leftIconInfo.customStyle
+                rightSecondIconInfo.customStyle
               )}
             ></Text>
           )}
-          <Text className='at-nav-bar__text'>{leftText}</Text>
         </View>
         <View
-          className='at-nav-bar__title'
-          onClick={this.handleClickTitle.bind(this)}
+          className={classNames({
+            'at-nav-bar__container': true,
+            'at-nav-bar__container--hide': !rightFirstIconType
+          })}
+          style={linkStyle}
+          onClick={handleClickSt}
         >
-          {title || this.props.children}
-        </View>
-        <View className='at-nav-bar__right-view'>
-          <View
-            className={classNames({
-              'at-nav-bar__container': true,
-              'at-nav-bar__container--hide': !rightSecondIconType
-            })}
-            style={linkStyle}
-            onClick={this.handleClickNd.bind(this)}
-          >
-            {rightSecondIconType && (
-              <Text
-                className={rightSecondIconClass}
-                style={mergeStyle(
-                  {
-                    color: rightSecondIconInfo.color,
-                    fontSize: `${pxTransform(
-                      parseInt(rightSecondIconInfo.size.toString()) * 2
-                    )}`
-                  },
-                  rightSecondIconInfo.customStyle
-                )}
-              ></Text>
-            )}
-          </View>
-          <View
-            className={classNames({
-              'at-nav-bar__container': true,
-              'at-nav-bar__container--hide': !rightFirstIconType
-            })}
-            style={linkStyle}
-            onClick={this.handleClickSt.bind(this)}
-          >
-            {rightFirstIconType && (
-              <Text
-                className={rightFirstIconClass}
-                style={mergeStyle(
-                  {
-                    color: rightFirstIconInfo.color,
-                    fontSize: `${pxTransform(
-                      parseInt(rightFirstIconInfo.size.toString()) * 2
-                    )}`
-                  },
-                  rightFirstIconInfo.customStyle
-                )}
-              ></Text>
-            )}
-          </View>
+          {rightFirstIconType && (
+            <Text
+              className={rightFirstIconClass}
+              style={mergeStyle(
+                {
+                  color: rightFirstIconInfo.color,
+                  fontSize: `${pxTransform(
+                    parseInt(rightFirstIconInfo.size.toString()) * 2
+                  )}`
+                },
+                rightFirstIconInfo.customStyle
+              )}
+            ></Text>
+          )}
         </View>
       </View>
-    )
-  }
-}
-
-AtNavBar.defaultProps = {
-  customStyle: '',
-  className: '',
-  fixed: false,
-  border: true,
-  color: '',
-  leftIconType: '',
-  leftText: '',
-  title: '',
-  rightFirstIconType: '',
-  rightSecondIconType: ''
+    </View>
+  )
 }
 
 AtNavBar.propTypes = {
@@ -213,3 +195,5 @@ AtNavBar.propTypes = {
   onClickRgIconNd: PropTypes.func,
   onClickTitle: PropTypes.func
 }
+
+export default AtNavBar

--- a/packages/taro-ui/src/components/noticebar/index.tsx
+++ b/packages/taro-ui/src/components/noticebar/index.tsx
@@ -1,84 +1,63 @@
 import classNames from 'classnames'
-import PropTypes, { InferProps } from 'prop-types'
-import React from 'react'
+import PropTypes from 'prop-types'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { Text, View } from '@tarojs/components'
 import { CommonEvent } from '@tarojs/components/types/common'
 import Taro from '@tarojs/taro'
-import { AtNoticeBarProps, AtNoticeBarState } from '../../../types/noticebar'
+import { AtNoticeBarProps } from '../../../types/noticebar'
 
-export default class AtNoticebar extends React.Component<
-  AtNoticeBarProps,
-  AtNoticeBarState
-> {
-  public static defaultProps: AtNoticeBarProps
-  public static propTypes: InferProps<AtNoticeBarProps>
+function AtNoticebar({
+  close = false,
+  single = false,
+  marquee = false,
+  speed = 100,
+  moreText = '查看详情',
+  showMore = false,
+  icon = '',
+  customStyle = {},
+  className,
+  children,
+  onClose,
+  onGotoMore
+}: AtNoticeBarProps): JSX.Element | boolean {
+  const [show, setShow] = useState(true)
+  const [animElemId] = useState(
+    () => `J_${Math.ceil(Math.random() * 10e5).toString(36)}`
+  )
+  const [animationData, setAnimationData] = useState<{
+    actions: Record<string, unknown>[]
+  }>({
+    actions: [{}]
+  })
+  const [dura, setDura] = useState(0)
+  const isWEAPP = Taro.getEnv() === Taro.ENV_TYPE.WEAPP
+  const isALIPAY = Taro.getEnv() === Taro.ENV_TYPE.ALIPAY
+  const isWEB = Taro.getEnv() === Taro.ENV_TYPE.WEB
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const animElemIdRef = useRef(animElemId)
 
-  private timeout: ReturnType<typeof setTimeout> | null
-  private interval: ReturnType<typeof setInterval> | null
-
-  public constructor(props: AtNoticeBarProps) {
-    super(props)
-    const animElemId = `J_${Math.ceil(Math.random() * 10e5).toString(36)}`
-    this.state = {
-      show: true,
-      animElemId,
-      animationData: {
-        actions: [{}]
-      },
-      dura: 0,
-      isWEAPP: Taro.getEnv() === Taro.ENV_TYPE.WEAPP,
-      isALIPAY: Taro.getEnv() === Taro.ENV_TYPE.ALIPAY,
-      isWEB: Taro.getEnv() === Taro.ENV_TYPE.WEB
-    }
-  }
-
-  private onClose(event: CommonEvent): void {
-    this.setState({
-      show: false
-    })
-    this.props.onClose && this.props.onClose(event)
-  }
-
-  private onGotoMore(event: CommonEvent): void {
-    this.props.onGotoMore && this.props.onGotoMore(event)
-  }
-
-  public UNSAFE_componentWillReceiveProps(): void {
-    if (!this.timeout) {
-      this.interval && clearInterval(this.interval)
-      this.initAnimation()
-    }
-  }
-
-  public componentDidMount(): void {
-    if (!this.props.marquee) return
-    this.initAnimation()
-  }
-
-  private initAnimation(): void {
-    const { isWEAPP, isALIPAY } = this.state
-    this.timeout = setTimeout(() => {
-      this.timeout = null
-      if (this.state.isWEB) {
-        const { speed = 100 } = this.props
-        const elem = document.querySelector(`.${this.state.animElemId}`)
+  const initAnimation = useCallback((): void => {
+    timeoutRef.current = setTimeout(() => {
+      timeoutRef.current = null
+      if (isWEB) {
+        const elem = document.querySelector(`.${animElemIdRef.current}`)
         if (!elem) return
         const width = elem.getBoundingClientRect().width
-        const dura = width / +speed
-        this.setState({ dura })
+        const animDura = width / +speed
+        setDura(animDura)
       } else if (isWEAPP || isALIPAY) {
         const query = Taro.createSelectorQuery()
         query
-          .select(`.${this.state.animElemId}`)
+          .select(`.${animElemIdRef.current}`)
           .boundingClientRect()
           .exec(res => {
             const queryRes = res[0]
             if (!queryRes) return
             const { width } = queryRes
-            const { speed = 100 } = this.props
-            const dura = width / +speed
+            const animDura = width / +speed
             const animation = Taro.createAnimation({
-              duration: dura * 1000,
+              duration: animDura * 1000,
               timingFunction: 'linear'
             })
             const resetAnimation = Taro.createAnimation({
@@ -91,126 +70,128 @@ export default class AtNoticebar extends React.Component<
             })
             const animBody = (): void => {
               resetOpacityAnimation.opacity(0).step()
-              this.setState({ animationData: resetOpacityAnimation.export() })
+              setAnimationData(resetOpacityAnimation.export())
 
               setTimeout(() => {
                 resetAnimation.translateX(0).step()
-                this.setState({ animationData: resetAnimation.export() })
+                setAnimationData(resetAnimation.export())
               }, 300)
 
               setTimeout(() => {
                 resetOpacityAnimation.opacity(1).step()
-                this.setState({ animationData: resetOpacityAnimation.export() })
+                setAnimationData(resetOpacityAnimation.export())
               }, 600)
 
               setTimeout(() => {
                 animation.translateX(-width).step()
-                this.setState({ animationData: animation.export() })
+                setAnimationData(animation.export())
               }, 900)
             }
             animBody()
-            this.interval = setInterval(animBody, dura * 1000 + 1000)
+            intervalRef.current = setInterval(animBody, animDura * 1000 + 1000)
           })
       }
     }, 1000)
+  }, [isWEB, isWEAPP, isALIPAY, speed])
+
+  useEffect(() => {
+    if (!marquee) return
+    initAnimation()
+  }, [marquee, initAnimation])
+
+  useEffect(() => {
+    if (!timeoutRef.current) {
+      intervalRef.current && clearInterval(intervalRef.current)
+      initAnimation()
+    }
+  }, [
+    children,
+    single,
+    marquee,
+    speed,
+    icon,
+    close,
+    showMore,
+    moreText,
+    className,
+    customStyle,
+    initAnimation
+  ])
+
+  const handleClose = (event: CommonEvent): void => {
+    setShow(false)
+    onClose && onClose(event)
   }
 
-  public render(): JSX.Element | boolean {
-    const {
-      single,
-      icon,
-      marquee,
-      customStyle,
-      className,
-      moreText = '查看详情'
-    } = this.props
-    let { showMore, close } = this.props
-    const { dura, show, animElemId, animationData, isWEAPP, isALIPAY } =
-      this.state
-    const rootClassName = ['at-noticebar']
+  const handleGotoMore = (event: CommonEvent): void => {
+    onGotoMore && onGotoMore(event)
+  }
 
-    if (!single) showMore = false
+  let resolvedShowMore = showMore
+  if (!single) resolvedShowMore = false
 
-    const style = {}
-    const innerClassName = ['at-noticebar__content-inner']
-    if (marquee) {
-      close = false
-      innerClassName.push(animElemId)
-      style['animation-delay'] = '3s'
+  const style: Record<string, string> = {}
+  const innerClassName = ['at-noticebar__content-inner']
+  let resolvedClose = close
+  if (marquee) {
+    resolvedClose = false
+    innerClassName.push(animElemId)
+    style['animation-delay'] = '3s'
 
-      if (dura > 0) {
-        style['animation-duration'] = `${dura}s`
-        style['animation-delay'] = '1s'
-      }
+    if (dura > 0) {
+      style['animation-duration'] = `${dura}s`
+      style['animation-delay'] = '1s'
     }
+  }
 
-    const classObject = {
-      'at-noticebar--marquee': marquee,
-      'at-noticebar--weapp': marquee && (isWEAPP || isALIPAY),
-      'at-noticebar--single': !marquee && single
-    }
+  const classObject = {
+    'at-noticebar--marquee': marquee,
+    'at-noticebar--weapp': marquee && (isWEAPP || isALIPAY),
+    'at-noticebar--single': !marquee && single
+  }
 
-    const iconClass = ['at-icon']
-    if (icon) iconClass.push(`at-icon-${icon}`)
+  const iconClass = ['at-icon']
+  if (icon) iconClass.push(`at-icon-${icon}`)
 
-    return (
-      show && (
-        <View
-          className={classNames(rootClassName, classObject, className)}
-          style={customStyle}
-        >
-          {close && (
-            <View
-              className='at-noticebar__close'
-              onClick={this.onClose.bind(this)}
-            >
-              <Text className='at-icon at-icon-close'></Text>
+  return (
+    show && (
+      <View
+        className={classNames('at-noticebar', classObject, className)}
+        style={customStyle}
+      >
+        {resolvedClose && (
+          <View className='at-noticebar__close' onClick={handleClose}>
+            <Text className='at-icon at-icon-close'></Text>
+          </View>
+        )}
+        <View className='at-noticebar__content'>
+          {icon && (
+            <View className='at-noticebar__content-icon'>
+              <Text className={classNames(iconClass, iconClass)}></Text>
             </View>
           )}
-          <View className='at-noticebar__content'>
-            {icon && (
-              <View className='at-noticebar__content-icon'>
-                {/* start hack 百度小程序 */}
-                <Text className={classNames(iconClass, iconClass)}></Text>
-              </View>
-            )}
-            <View className='at-noticebar__content-text'>
-              <View
-                id={animElemId}
-                animation={animationData}
-                className={classNames(innerClassName)}
-                style={style}
-              >
-                {this.props.children}
-              </View>
+          <View className='at-noticebar__content-text'>
+            <View
+              id={animElemId}
+              animation={animationData}
+              className={classNames(innerClassName)}
+              style={style}
+            >
+              {children}
             </View>
           </View>
-          {showMore && (
-            <View
-              className='at-noticebar__more'
-              onClick={this.onGotoMore.bind(this)}
-            >
-              <Text className='text'>{moreText}</Text>
-              <View className='at-noticebar__more-icon'>
-                <Text className='at-icon at-icon-chevron-right'></Text>
-              </View>
-            </View>
-          )}
         </View>
-      )
+        {resolvedShowMore && (
+          <View className='at-noticebar__more' onClick={handleGotoMore}>
+            <Text className='text'>{moreText}</Text>
+            <View className='at-noticebar__more-icon'>
+              <Text className='at-icon at-icon-chevron-right'></Text>
+            </View>
+          </View>
+        )}
+      </View>
     )
-  }
-}
-
-AtNoticebar.defaultProps = {
-  close: false,
-  single: false,
-  marquee: false,
-  speed: 100,
-  moreText: '查看详情',
-  showMore: false,
-  icon: '',
-  customStyle: {}
+  )
 }
 
 AtNoticebar.propTypes = {
@@ -225,3 +206,5 @@ AtNoticebar.propTypes = {
   onClose: PropTypes.func,
   onGotoMore: PropTypes.func
 }
+
+export default AtNoticebar

--- a/packages/taro-ui/src/components/pagination/index.tsx
+++ b/packages/taro-ui/src/components/pagination/index.tsx
@@ -1,8 +1,8 @@
 import classNames from 'classnames'
-import PropTypes, { InferProps } from 'prop-types'
-import React from 'react'
+import PropTypes from 'prop-types'
+import React, { useEffect, useState } from 'react'
 import { Text, View } from '@tarojs/components'
-import { AtPaginationProps, AtPaginationState } from '../../../types/pagination'
+import { AtPaginationProps } from '../../../types/pagination'
 import AtButton from '../button/index'
 
 const MIN_MAXPAGE = 1
@@ -16,160 +16,98 @@ const createPickerRange = (max: number): number[] => {
   return range
 }
 
-export default class AtPagination extends React.Component<
-  AtPaginationProps,
-  AtPaginationState
-> {
-  public static defaultProps: AtPaginationProps
-  public static propTypes: InferProps<AtPaginationProps>
+function AtPagination({
+  current = 1,
+  total = 0,
+  pageSize = 20,
+  icon = false,
+  customStyle = {},
+  className,
+  onPageChange
+}: AtPaginationProps): JSX.Element {
+  const initialMaxPage = getMaxPage(Math.ceil(total / pageSize))
+  const [currentPage, setCurrentPage] = useState(current || 1)
+  const [maxPage, setMaxPage] = useState(initialMaxPage)
+  const [, setPickerRange] = useState(() => createPickerRange(initialMaxPage))
 
-  public constructor(props: AtPaginationProps) {
-    super(props)
-    const { current, pageSize = 20, total } = this.props
-    const maxPage = getMaxPage(Math.ceil(total / pageSize))
-    this.state = {
-      currentPage: current || 1,
-      maxPage,
-      pickerRange: createPickerRange(maxPage)
+  useEffect(() => {
+    const newMaxPage = getMaxPage(Math.ceil(total / pageSize))
+    setMaxPage(prev => {
+      if (newMaxPage !== prev) {
+        setPickerRange(createPickerRange(newMaxPage))
+        return newMaxPage
+      }
+      return prev
+    })
+    if (typeof current === 'number') {
+      setCurrentPage(prev => (current !== prev ? current : prev))
     }
+  }, [total, pageSize, current])
+
+  const onPrev = (): void => {
+    let nextPage = currentPage
+    const originCur = nextPage
+    nextPage -= 1
+    nextPage = Math.max(1, nextPage)
+    if (originCur === nextPage) return
+    onPageChange && onPageChange({ type: 'prev', current: nextPage })
+    setCurrentPage(nextPage)
   }
 
-  private onPrev(): void {
-    let { currentPage } = this.state
-    const originCur = currentPage
-    currentPage -= 1
-    currentPage = Math.max(1, currentPage)
-    if (originCur === currentPage) return
-    this.props.onPageChange &&
-      this.props.onPageChange({ type: 'prev', current: currentPage })
-    this.setState({ currentPage })
+  const onNext = (): void => {
+    let nextPage = currentPage
+    const originCur = nextPage
+    nextPage += 1
+    nextPage = Math.min(maxPage, nextPage)
+    if (originCur === nextPage) return
+    onPageChange && onPageChange({ type: 'next', current: nextPage })
+    setCurrentPage(nextPage)
   }
 
-  private onNext(): void {
-    let { currentPage } = this.state
-    const originCur = currentPage
-    const { maxPage } = this.state
-    currentPage += 1
-    currentPage = Math.min(maxPage, currentPage)
-    if (originCur === currentPage) return
-    this.props.onPageChange &&
-      this.props.onPageChange({ type: 'next', current: currentPage })
-    this.setState({ currentPage })
+  const rootClassName = ['at-pagination']
+
+  const prevDisabled = maxPage === MIN_MAXPAGE || currentPage === 1
+  const nextDisabled = maxPage === MIN_MAXPAGE || currentPage === maxPage
+
+  const classObject = {
+    'at-pagination--icon': icon
   }
 
-  public UNSAFE_componentWillReceiveProps(props: AtPaginationProps): void {
-    const { total, pageSize = 20, current } = props
-    const maxPage = getMaxPage(Math.ceil(total / pageSize))
-    if (maxPage !== this.state.maxPage) {
-      this.setState({
-        maxPage,
-        pickerRange: createPickerRange(maxPage)
-      })
-    }
-    if (typeof current === 'number' && current !== this.state.currentPage) {
-      this.setState({ currentPage: current })
-    }
-  }
-
-  // onPickerChange (evt) {
-  //   const { value } = evt.detail
-  //   const current = +value + 1
-  //   if (current === this.state.currentPage) return
-  //   this.props.onPageChange && this.props.onPageChange({ type: 'pick', current })
-  //   this.setState({
-  //     currentPage: current,
-  //   })
-  // }
-
-  public render(): JSX.Element {
-    const {
-      icon,
-      // pickerSelect,
-      customStyle
-    } = this.props
-    const {
-      currentPage,
-      maxPage
-      // pickerRange,
-    } = this.state
-
-    const rootClassName = ['at-pagination']
-
-    const prevDisabled = maxPage === MIN_MAXPAGE || currentPage === 1
-    const nextDisabled = maxPage === MIN_MAXPAGE || currentPage === maxPage
-
-    const classObject = {
-      'at-pagination--icon': icon
-    }
-
-    return (
-      <View
-        className={classNames(rootClassName, classObject, this.props.className)}
-        style={customStyle}
-      >
-        <View className='at-pagination__btn-prev'>
-          {icon && (
-            <AtButton
-              onClick={this.onPrev.bind(this)}
-              size='small'
-              disabled={prevDisabled}
-            >
-              <Text className='at-icon at-icon-chevron-left'></Text>
-            </AtButton>
-          )}
-          {!icon && (
-            <AtButton
-              onClick={this.onPrev.bind(this)}
-              size='small'
-              disabled={prevDisabled}
-            >
-              上一页
-            </AtButton>
-          )}
-        </View>
-        <View className='at-pagination__number'>
-          <Text className='at-pagination__number-current'>{currentPage}</Text>/
-          {maxPage}
-        </View>
-        <View className='at-pagination__btn-next'>
-          {icon && (
-            <AtButton
-              onClick={this.onNext.bind(this)}
-              size='small'
-              disabled={nextDisabled}
-            >
-              <Text className='at-icon at-icon-chevron-right'></Text>
-            </AtButton>
-          )}
-          {!icon && (
-            <AtButton
-              onClick={this.onNext.bind(this)}
-              size='small'
-              disabled={nextDisabled}
-            >
-              下一页
-            </AtButton>
-          )}
-        </View>
-        {/* {pickerSelect && <View className='at-pagination__number'>
-          {<Picker mode='selector' range={pickerRange} value={currentPage - 1} onChange={this.onPickerChange.bind(this)}>
-            <Text className='at-pagination__number-current'>{currentPage}</Text>/{ maxPage }
-          </Picker>}
-        </View>} */}
-        {/* {!pickerSelect && <View className='at-pagination__number'>
-          <Text className='at-pagination__number-current'>{currentPage}</Text>/{ maxPage }
-        </View>} */}
+  return (
+    <View
+      className={classNames(rootClassName, classObject, className)}
+      style={customStyle}
+    >
+      <View className='at-pagination__btn-prev'>
+        {icon && (
+          <AtButton onClick={onPrev} size='small' disabled={prevDisabled}>
+            <Text className='at-icon at-icon-chevron-left'></Text>
+          </AtButton>
+        )}
+        {!icon && (
+          <AtButton onClick={onPrev} size='small' disabled={prevDisabled}>
+            上一页
+          </AtButton>
+        )}
       </View>
-    )
-  }
-}
-
-AtPagination.defaultProps = {
-  current: 1,
-  total: 0,
-  pageSize: 20,
-  icon: false,
-  customStyle: {}
+      <View className='at-pagination__number'>
+        <Text className='at-pagination__number-current'>{currentPage}</Text>/
+        {maxPage}
+      </View>
+      <View className='at-pagination__btn-next'>
+        {icon && (
+          <AtButton onClick={onNext} size='small' disabled={nextDisabled}>
+            <Text className='at-icon at-icon-chevron-right'></Text>
+          </AtButton>
+        )}
+        {!icon && (
+          <AtButton onClick={onNext} size='small' disabled={nextDisabled}>
+            下一页
+          </AtButton>
+        )}
+      </View>
+    </View>
+  )
 }
 
 AtPagination.propTypes = {
@@ -180,3 +118,5 @@ AtPagination.propTypes = {
   customStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
   onPageChange: PropTypes.func
 }
+
+export default AtPagination

--- a/packages/taro-ui/src/components/progress/index.tsx
+++ b/packages/taro-ui/src/components/progress/index.tsx
@@ -1,68 +1,68 @@
 import classNames from 'classnames'
-import PropTypes, { InferProps } from 'prop-types'
+import PropTypes from 'prop-types'
 import React from 'react'
 import { Text, View } from '@tarojs/components'
 import { AtProgressProps } from '../../../types/progress'
 
-export default class AtProgress extends React.Component<AtProgressProps> {
-  public static propTypes: InferProps<AtProgressProps>
-
-  public render(): JSX.Element {
-    const { color } = this.props
-    let { percent } = this.props
-    const { strokeWidth, status, isHidePercent } = this.props
-
-    if (typeof percent !== 'number') {
-      percent = 0
-    }
-
-    if (percent < 0) {
-      percent = 0
-    } else if (percent > 100) {
-      percent = 100
-    }
-
-    const rootClass = classNames(
-      'at-progress',
-      {
-        [`at-progress--${status}`]: !!status
-      },
-      this.props.className
-    )
-    const iconClass = classNames('at-icon', {
-      'at-icon-close-circle': status === 'error',
-      'at-icon-check-circle': status === 'success'
-    })
-
-    const progressStyle = {
-      width: percent && `${+percent}%`,
-      height: strokeWidth && `${+strokeWidth}px`,
-      backgroundColor: color
-    }
-
-    return (
-      <View className={rootClass}>
-        <View className='at-progress__outer'>
-          <View className='at-progress__outer-inner'>
-            <View
-              className='at-progress__outer-inner-background'
-              style={progressStyle}
-            />
-          </View>
-        </View>
-
-        {!isHidePercent && (
-          <View className='at-progress__content'>
-            {!status || status === 'progress' ? (
-              `${percent}%`
-            ) : (
-              <Text className={iconClass}></Text>
-            )}
-          </View>
-        )}
-      </View>
-    )
+export default function AtProgress({
+  color,
+  percent: percentProp,
+  strokeWidth,
+  status,
+  isHidePercent,
+  className
+}: AtProgressProps): JSX.Element {
+  let percent = percentProp
+  if (typeof percent !== 'number') {
+    percent = 0
   }
+
+  if (percent < 0) {
+    percent = 0
+  } else if (percent > 100) {
+    percent = 100
+  }
+
+  const rootClass = classNames(
+    'at-progress',
+    {
+      [`at-progress--${status}`]: !!status
+    },
+    className
+  )
+  const iconClass = classNames('at-icon', {
+    'at-icon-close-circle': status === 'error',
+    'at-icon-check-circle': status === 'success'
+  })
+
+  const progressStyle = {
+    width: percent && `${+percent}%`,
+    height: strokeWidth && `${+strokeWidth}px`,
+    backgroundColor: color
+  }
+
+  return (
+    <View className={rootClass}>
+      <View className='at-progress__outer'>
+        <View className='at-progress__outer-inner'>
+          <View
+            className='at-progress__outer-inner-background'
+            style={progressStyle}
+          />
+        </View>
+      </View>
+
+      {!isHidePercent && (
+        <View className='at-progress__content'>
+          {!status || status === 'progress' ? (
+            `${percent}%`
+          ) : (
+            <Text className={iconClass}></Text>
+          )}
+        </View>
+      )}
+    </View>
+  )
 }
 
 AtProgress.propTypes = {

--- a/packages/taro-ui/src/components/radio/index.tsx
+++ b/packages/taro-ui/src/components/radio/index.tsx
@@ -1,63 +1,54 @@
 import classNames from 'classnames'
-import PropTypes, { InferProps } from 'prop-types'
+import PropTypes from 'prop-types'
 import React from 'react'
 import { Text, View } from '@tarojs/components'
 import { CommonEvent } from '@tarojs/components/types/common'
 import { AtRadioProps, RadioOption } from '../../../types/radio'
+import { noop } from '../../common/utils'
 
-export default class AtRadio extends React.Component<AtRadioProps<any>> {
-  public static defaultProps: AtRadioProps<any>
-  public static propTypes: InferProps<AtRadioProps<any>>
-
-  private handleClick(option: RadioOption<any>, event: CommonEvent): void {
+function AtRadio({
+  customStyle = '',
+  className = '',
+  value = '',
+  options = [],
+  onClick = noop
+}: AtRadioProps<any>): JSX.Element {
+  const handleClick = (option: RadioOption<any>, event: CommonEvent): void => {
     if (option.disabled) return
-    this.props.onClick(option.value, event)
+    onClick(option.value, event)
   }
 
-  public render(): JSX.Element {
-    const { customStyle, className, options, value } = this.props
-
-    return (
-      <View className={classNames('at-radio', className)} style={customStyle}>
-        {options.map(option => (
-          <View
-            key={option.value}
-            onClick={this.handleClick.bind(this, option)}
-            className={classNames({
-              'at-radio__option': true,
-              'at-radio__option--disabled': option.disabled
-            })}
-          >
-            <View className='at-radio__option-wrap'>
-              <View className='at-radio__option-container'>
-                <View className='at-radio__title'>{option.label}</View>
-                <View
-                  className={classNames({
-                    'at-radio__icon': true,
-                    'at-radio__icon--checked': value === option.value
-                  })}
-                >
-                  <Text className='at-icon at-icon-check'></Text>
-                </View>
+  return (
+    <View className={classNames('at-radio', className)} style={customStyle}>
+      {options.map(option => (
+        <View
+          key={option.value}
+          onClick={event => handleClick(option, event)}
+          className={classNames({
+            'at-radio__option': true,
+            'at-radio__option--disabled': option.disabled
+          })}
+        >
+          <View className='at-radio__option-wrap'>
+            <View className='at-radio__option-container'>
+              <View className='at-radio__title'>{option.label}</View>
+              <View
+                className={classNames({
+                  'at-radio__icon': true,
+                  'at-radio__icon--checked': value === option.value
+                })}
+              >
+                <Text className='at-icon at-icon-check'></Text>
               </View>
-              {option.desc && (
-                <View className='at-radio__desc'>{option.desc}</View>
-              )}
             </View>
+            {option.desc && (
+              <View className='at-radio__desc'>{option.desc}</View>
+            )}
           </View>
-        ))}
-      </View>
-    )
-  }
-}
-
-AtRadio.defaultProps = {
-  customStyle: '',
-  className: '',
-  value: '',
-  options: [],
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  onClick: (): void => {}
+        </View>
+      ))}
+    </View>
+  )
 }
 
 AtRadio.propTypes = {
@@ -67,3 +58,5 @@ AtRadio.propTypes = {
   options: PropTypes.array,
   onClick: PropTypes.func
 }
+
+export default AtRadio

--- a/packages/taro-ui/src/components/range/index.tsx
+++ b/packages/taro-ui/src/components/range/index.tsx
@@ -1,212 +1,192 @@
 import classNames from 'classnames'
-import PropTypes, { InferProps } from 'prop-types'
-import React from 'react'
+import PropTypes from 'prop-types'
+import React, { useEffect, useRef, useState } from 'react'
 import { View } from '@tarojs/components'
 import { CommonEvent, ITouchEvent } from '@tarojs/components/types/common'
-import { AtRangeProps, AtRangeState } from '../../../types/range'
+import { AtRangeProps } from '../../../types/range'
 import {
   delayQuerySelector,
   getEventDetail,
   mergeStyle
 } from '../../common/utils'
 
-export default class AtRange extends React.Component<
-  AtRangeProps,
-  AtRangeState
-> {
-  public static defaultProps: AtRangeProps
-  public static propTypes: InferProps<AtRangeProps>
+function AtRange({
+  customStyle = '',
+  className = '',
+  sliderStyle = {},
+  railStyle = {},
+  trackStyle = {},
+  value = [0, 0],
+  min = 0,
+  max = 100,
+  disabled = false,
+  blockSize = 0,
+  onChange,
+  onAfterChange
+}: AtRangeProps): JSX.Element {
+  const widthRef = useRef(0)
+  const leftRef = useRef(0)
+  const deltaValueRef = useRef(max - min)
+  const currentSliderRef = useRef('')
+  const [{ aX, bX }, setAxis] = useState({ aX: 0, bX: 0 })
+  const stateRef = useRef({ aX: 0, bX: 0 })
+  stateRef.current = { aX, bX }
 
-  private width: number
-  private left: number
-  private deltaValue: number
-  private currentSlider: string
+  deltaValueRef.current = max - min
 
-  public constructor(props: AtRangeProps) {
-    super(props)
-    const { min = 0, max = 100 } = props
-    // range 宽度
-    this.width = 0
-    // range 到屏幕左边的距离
-    this.left = 0
-    this.deltaValue = max - min
-    this.currentSlider = ''
-    this.state = {
-      aX: 0,
-      bX: 0
-    }
-  }
-
-  private handleClick = (event: CommonEvent): void => {
-    if (this.currentSlider && !this.props.disabled) {
-      let sliderValue = 0
-      const detail = getEventDetail(event)
-      sliderValue = detail.x - this.left
-      this.setSliderValue(this.currentSlider, sliderValue, 'onChange')
-    }
-  }
-
-  private handleTouchMove(sliderName: string, event: ITouchEvent): void {
-    if (this.props.disabled) return
-    event.stopPropagation()
-
-    const clientX = event.touches[0].clientX
-    this.setSliderValue(sliderName, clientX - this.left, 'onChange')
-  }
-
-  private handleTouchEnd(sliderName: string): void {
-    if (this.props.disabled) return
-
-    this.currentSlider = sliderName
-    this.triggerEvent('onAfterChange')
-  }
-
-  private setSliderValue(
-    sliderName: string,
-    targetValue: number,
-    funcName: string
-  ): void {
-    const distance = Math.min(Math.max(targetValue, 0), this.width)
-    const sliderValue = Math.floor((distance / this.width) * 100)
-    if (funcName) {
-      this.setState(
-        {
-          [sliderName]: sliderValue
-        },
-        () => this.triggerEvent(funcName)
-      )
-    } else {
-      this.setState({
-        [sliderName]: sliderValue
-      })
-    }
-  }
-
-  private setValue(value: number[]): void {
-    const { min = 0 } = this.props
-    const aX = Math.round(((value[0] - min) / this.deltaValue) * 100) // fix issue #670
-    const bX = Math.round(((value[1] - min) / this.deltaValue) * 100) // fix issue #670
-    this.setState({ aX, bX })
-  }
-
-  private triggerEvent(funcName: string): void {
-    const { min = 0 } = this.props
-    const { aX, bX } = this.state
-    const a = Math.round((aX / 100) * this.deltaValue) + min // fix issue #670
-    const b = Math.round((bX / 100) * this.deltaValue) + min // fix issue #670
+  const triggerEvent = (funcName: string): void => {
+    const { aX: stateAX, bX: stateBX } = stateRef.current
+    const a = Math.round((stateAX / 100) * deltaValueRef.current) + min
+    const b = Math.round((stateBX / 100) * deltaValueRef.current) + min
     const result = [a, b].sort((x, y) => x - y) as [number, number]
 
     if (funcName === 'onChange') {
-      this.props.onChange && this.props.onChange(result)
+      onChange && onChange(result)
     } else if (funcName === 'onAfterChange') {
-      this.props.onAfterChange && this.props.onAfterChange(result)
+      onAfterChange && onAfterChange(result)
     }
   }
 
-  private updatePos(): void {
+  const setValue = (nextValue: number[]): void => {
+    const aXVal = Math.round(
+      ((nextValue[0] - min) / deltaValueRef.current) * 100
+    )
+    const bXVal = Math.round(
+      ((nextValue[1] - min) / deltaValueRef.current) * 100
+    )
+    setAxis({ aX: aXVal, bX: bXVal })
+  }
+
+  const setSliderValue = (
+    sliderName: string,
+    targetValue: number,
+    funcName: string
+  ): void => {
+    const distance = Math.min(Math.max(targetValue, 0), widthRef.current)
+    const sliderValue = Math.floor((distance / widthRef.current) * 100)
+    if (funcName) {
+      setAxis(prev => {
+        const next = { ...prev, [sliderName]: sliderValue }
+        stateRef.current = next
+        const a = Math.round((next.aX / 100) * deltaValueRef.current) + min
+        const b = Math.round((next.bX / 100) * deltaValueRef.current) + min
+        const result = [a, b].sort((x, y) => x - y) as [number, number]
+        if (funcName === 'onChange') {
+          onChange && onChange(result)
+        } else if (funcName === 'onAfterChange') {
+          onAfterChange && onAfterChange(result)
+        }
+        return next
+      })
+    } else {
+      setAxis(prev => ({ ...prev, [sliderName]: sliderValue }))
+    }
+  }
+
+  const updatePos = (): void => {
     delayQuerySelector('.at-range__container', 0).then(rect => {
-      this.width = Math.round(rect[0]?.width)
-      this.left = Math.round(rect[0]?.left)
+      widthRef.current = Math.round(rect[0]?.width)
+      leftRef.current = Math.round(rect[0]?.left)
     })
   }
 
-  public UNSAFE_componentWillReceiveProps(nextProps: AtRangeProps): void {
-    const { value = [] } = nextProps
-    this.updatePos()
+  const handleClick = (event: CommonEvent): void => {
+    if (currentSliderRef.current && !disabled) {
+      let sliderValue = 0
+      const detail = getEventDetail(event)
+      sliderValue = detail.x - leftRef.current
+      setSliderValue(currentSliderRef.current, sliderValue, 'onChange')
+    }
+  }
+
+  const handleTouchMove = (sliderName: string, event: ITouchEvent): void => {
+    if (disabled) return
+    event.stopPropagation()
+
+    const clientX = event.touches[0].clientX
+    setSliderValue(sliderName, clientX - leftRef.current, 'onChange')
+  }
+
+  const handleTouchEnd = (sliderName: string): void => {
+    if (disabled) return
+
+    currentSliderRef.current = sliderName
+    triggerEvent('onAfterChange')
+  }
+
+  useEffect(() => {
+    updatePos()
+    setValue(value)
+    // componentDidMount
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const prevValueRef = useRef(value)
+  useEffect(() => {
+    updatePos()
     if (
-      this.props.value?.[0] !== value?.[0] ||
-      this.props.value?.[1] !== value?.[1]
+      prevValueRef.current?.[0] !== value?.[0] ||
+      prevValueRef.current?.[1] !== value?.[1]
     ) {
-      this.setValue(value)
+      setValue(value)
     }
+    prevValueRef.current = value
+  }, [value, min, max])
+
+  const rootCls = classNames(
+    'at-range',
+    {
+      'at-range--disabled': disabled
+    },
+    className
+  )
+
+  const sliderCommonStyle = {
+    width: blockSize ? `${blockSize}PX` : '',
+    height: blockSize ? `${blockSize}PX` : '',
+    marginLeft: blockSize ? `${-blockSize / 2}PX` : ''
+  }
+  const sliderAStyle = {
+    ...sliderCommonStyle,
+    left: `${aX}%`
+  }
+  const sliderBStyle = {
+    ...sliderCommonStyle,
+    left: `${bX}%`
+  }
+  const containerStyle = {
+    height: blockSize ? `${blockSize}PX` : ''
+  }
+  const smallerX = Math.min(aX, bX)
+  const deltaX = Math.abs(aX - bX)
+  const atTrackStyle = {
+    left: `${smallerX}%`,
+    width: `${deltaX}%`
   }
 
-  public componentDidMount(): void {
-    const { value = [] } = this.props
-    this.updatePos()
-    this.setValue(value)
-  }
-
-  public render(): JSX.Element {
-    const {
-      className,
-      customStyle,
-      sliderStyle = {},
-      railStyle = {},
-      trackStyle = {},
-      blockSize,
-      disabled
-    } = this.props
-
-    const rootCls = classNames(
-      'at-range',
-      {
-        'at-range--disabled': disabled
-      },
-      className
-    )
-
-    const { aX, bX } = this.state
-    const sliderCommonStyle = {
-      width: blockSize ? `${blockSize}PX` : '',
-      height: blockSize ? `${blockSize}PX` : '',
-      marginLeft: blockSize ? `${-blockSize / 2}PX` : ''
-    }
-    const sliderAStyle = {
-      ...sliderCommonStyle,
-      left: `${aX}%`
-    }
-    const sliderBStyle = {
-      ...sliderCommonStyle,
-      left: `${bX}%`
-    }
-    const containerStyle = {
-      height: blockSize ? `${blockSize}PX` : ''
-    }
-    const smallerX = Math.min(aX, bX)
-    const deltaX = Math.abs(aX - bX)
-    const atTrackStyle = {
-      left: `${smallerX}%`,
-      width: `${deltaX}%`
-    }
-
-    return (
-      <View className={rootCls} style={customStyle} onClick={this.handleClick}>
-        <View className='at-range__container' style={containerStyle}>
-          <View className='at-range__rail' style={railStyle}></View>
-          <View
-            className='at-range__track'
-            style={mergeStyle(atTrackStyle, trackStyle)}
-          ></View>
-          <View
-            className='at-range__slider'
-            style={mergeStyle(sliderAStyle, sliderStyle)}
-            onTouchMove={this.handleTouchMove.bind(this, 'aX')}
-            onTouchEnd={this.handleTouchEnd.bind(this, 'aX')}
-          ></View>
-          <View
-            className='at-range__slider'
-            style={mergeStyle(sliderBStyle, sliderStyle)}
-            onTouchMove={this.handleTouchMove.bind(this, 'bX')}
-            onTouchEnd={this.handleTouchEnd.bind(this, 'bX')}
-          ></View>
-        </View>
+  return (
+    <View className={rootCls} style={customStyle} onClick={handleClick}>
+      <View className='at-range__container' style={containerStyle}>
+        <View className='at-range__rail' style={railStyle}></View>
+        <View
+          className='at-range__track'
+          style={mergeStyle(atTrackStyle, trackStyle)}
+        ></View>
+        <View
+          className='at-range__slider'
+          style={mergeStyle(sliderAStyle, sliderStyle)}
+          onTouchMove={(event: ITouchEvent) => handleTouchMove('aX', event)}
+          onTouchEnd={() => handleTouchEnd('aX')}
+        ></View>
+        <View
+          className='at-range__slider'
+          style={mergeStyle(sliderBStyle, sliderStyle)}
+          onTouchMove={(event: ITouchEvent) => handleTouchMove('bX', event)}
+          onTouchEnd={() => handleTouchEnd('bX')}
+        ></View>
       </View>
-    )
-  }
-}
-
-AtRange.defaultProps = {
-  customStyle: '',
-  className: '',
-  sliderStyle: '',
-  railStyle: '',
-  trackStyle: '',
-  value: [0, 0],
-  min: 0,
-  max: 100,
-  disabled: false,
-  blockSize: 0
+    </View>
+  )
 }
 
 AtRange.propTypes = {
@@ -223,3 +203,5 @@ AtRange.propTypes = {
   onChange: PropTypes.func,
   onAfterChange: PropTypes.func
 }
+
+export default AtRange

--- a/packages/taro-ui/src/components/rate/index.tsx
+++ b/packages/taro-ui/src/components/rate/index.tsx
@@ -1,83 +1,65 @@
 import classNames from 'classnames'
-import PropTypes, { InferProps } from 'prop-types'
+import PropTypes from 'prop-types'
 import React from 'react'
 import { Text, View } from '@tarojs/components'
 import { CommonEvent } from '@tarojs/components/types/common'
 import { AtRateProps } from '../../../types/rate'
 import { pxTransform } from '../../common/utils'
 
-export default class AtRate extends React.Component<AtRateProps> {
-  public static defaultProps: AtRateProps
-  public static propTypes: InferProps<AtRateProps>
-
-  private handleClick(event: CommonEvent): void {
-    this.props.onChange && this.props.onChange(event)
+function AtRate({
+  customStyle = '',
+  className = '',
+  value = 0,
+  max = 5,
+  size = 0,
+  margin = 5,
+  onChange
+}: AtRateProps): JSX.Element {
+  const handleClick = (event: CommonEvent): void => {
+    onChange && onChange(event)
   }
 
-  public render(): JSX.Element {
-    const {
-      customStyle,
-      className,
-      value = 0,
-      max = 5,
-      size,
-      margin = 5
-    } = this.props
+  const iconStyle = {
+    marginRight: pxTransform(margin)
+  }
+  const starIconStyle = {
+    fontSize: size ? `${size}px` : ''
+  }
 
-    const iconStyle = {
-      marginRight: pxTransform(margin)
+  // 生成星星颜色 className 数组，方便在jsx中直接map
+  const classNameArr: string[] = []
+  const floorValue = Math.floor(value)
+  const ceilValue = Math.ceil(value)
+  for (let i = 0; i < max; i++) {
+    if (floorValue > i) {
+      classNameArr.push('at-rate__icon at-rate__icon--on')
+    } else if (ceilValue - 1 === i) {
+      classNameArr.push('at-rate__icon at-rate__icon--half')
+    } else {
+      classNameArr.push('at-rate__icon at-rate__icon--off')
     }
-    const starIconStyle = {
-      fontSize: size ? `${size}px` : ''
-    }
+  }
 
-    // 生成星星颜色 className 数组，方便在jsx中直接map
-    const classNameArr: string[] = []
-    const floorValue = Math.floor(value)
-    const ceilValue = Math.ceil(value)
-    for (let i = 0; i < max; i++) {
-      if (floorValue > i) {
-        classNameArr.push('at-rate__icon at-rate__icon--on')
-      } else if (ceilValue - 1 === i) {
-        classNameArr.push('at-rate__icon at-rate__icon--half')
-      } else {
-        classNameArr.push('at-rate__icon at-rate__icon--off')
-      }
-    }
-
-    return (
-      <View className={classNames('at-rate', className)} style={customStyle}>
-        {classNameArr.map((cls, i) => (
-          <View
-            className={cls}
-            key={`at-rate-star-${i}`}
-            style={iconStyle}
-            onClick={this.handleClick.bind(this, i + 1)}
-          >
+  return (
+    <View className={classNames('at-rate', className)} style={customStyle}>
+      {classNameArr.map((cls, i) => (
+        <View
+          className={cls}
+          key={`at-rate-star-${i}`}
+          style={iconStyle}
+          onClick={handleClick.bind(null, i + 1)}
+        >
+          <Text className='at-icon at-icon-star-2' style={starIconStyle}></Text>
+          <View className='at-rate__left'>
             <Text
               className='at-icon at-icon-star-2'
               style={starIconStyle}
             ></Text>
-            <View className='at-rate__left'>
-              <Text
-                className='at-icon at-icon-star-2'
-                style={starIconStyle}
-              ></Text>
-            </View>
           </View>
-        ))}
-      </View>
-    )
-  }
-}
-
-AtRate.defaultProps = {
-  customStyle: '',
-  className: '',
-  size: 0,
-  value: 0,
-  max: 5,
-  margin: 5
+        </View>
+      ))}
+    </View>
+  )
 }
 
 AtRate.propTypes = {
@@ -89,3 +71,5 @@ AtRate.propTypes = {
   margin: PropTypes.number,
   onChange: PropTypes.func
 }
+
+export default AtRate

--- a/packages/taro-ui/src/components/search-bar/index.tsx
+++ b/packages/taro-ui/src/components/search-bar/index.tsx
@@ -1,9 +1,9 @@
 import classNames from 'classnames'
-import PropTypes, { InferProps } from 'prop-types'
-import React from 'react'
+import PropTypes from 'prop-types'
+import React, { useEffect, useState } from 'react'
 import { Input, Text, View } from '@tarojs/components'
 import { CommonEvent } from '@tarojs/components/types/common'
-import { AtSearchBarProps, AtSearchBarState } from '../../../types/search-bar'
+import { AtSearchBarProps } from '../../../types/search-bar'
 
 type ExtendEvent = {
   target: {
@@ -11,171 +11,139 @@ type ExtendEvent = {
   }
 }
 
-export default class AtSearchBar extends React.Component<
-  AtSearchBarProps,
-  AtSearchBarState
-> {
-  public static defaultProps: AtSearchBarProps
-  public static propTypes: InferProps<AtSearchBarProps>
+function AtSearchBar({
+  value = '',
+  placeholder = '搜索',
+  maxLength = 140,
+  fixed = false,
+  focus = false,
+  disabled = false,
+  showActionButton = false,
+  actionName = '搜索',
+  inputType = 'text',
+  className,
+  customStyle,
+  enableNative = true,
+  onChange,
+  onFocus,
+  onBlur,
+  onConfirm,
+  onActionClick,
+  onClear
+}: AtSearchBarProps): JSX.Element {
+  const [isFocus, setIsFocus] = useState(!!focus)
 
-  public constructor(props: AtSearchBarProps) {
-    super(props)
-    this.state = {
-      isFocus: !!props.focus
-    }
+  useEffect(() => {
+    setIsFocus(!!focus)
+  }, [focus])
+
+  const handleFocus = (event: CommonEvent): void => {
+    setIsFocus(true)
+    onFocus && onFocus(event)
   }
 
-  private handleFocus = (event: CommonEvent): void => {
-    this.setState({
-      isFocus: true
-    })
-    this.props.onFocus && this.props.onFocus(event)
+  const handleBlur = (event: CommonEvent): void => {
+    setIsFocus(false)
+    onBlur && onBlur(event)
   }
 
-  private handleBlur = (event: CommonEvent): void => {
-    this.setState({
-      isFocus: false
-    })
-    this.props.onBlur && this.props.onBlur(event)
+  const handleChange = (e: CommonEvent & ExtendEvent): void => {
+    onChange && onChange(e.detail.value, e)
   }
 
-  private handleChange = (e: CommonEvent & ExtendEvent): void => {
-    this.props.onChange(e.detail.value, e)
-  }
-
-  private handleClear = (event: CommonEvent): void => {
-    if (this.props.onClear) {
-      this.props.onClear(event)
+  const handleClear = (event: CommonEvent): void => {
+    if (onClear) {
+      onClear(event)
     } else {
-      this.props.onChange('', event)
+      onChange && onChange('', event)
     }
   }
 
-  private handleConfirm = (event: CommonEvent): void => {
-    this.props.onConfirm && this.props.onConfirm(event)
+  const handleConfirm = (event: CommonEvent): void => {
+    onConfirm && onConfirm(event)
   }
 
-  private handleActionClick = (event: CommonEvent): void => {
-    this.props.onActionClick && this.props.onActionClick(event)
+  const handleActionClick = (event: CommonEvent): void => {
+    onActionClick && onActionClick(event)
   }
 
-  public UNSAFE_componentWillReceiveProps(nextProps: AtSearchBarProps): void {
-    if (nextProps.focus !== this.props.focus) {
-      this.setState({ isFocus: !!nextProps.focus })
-    }
+  const fontSize = 14
+  const rootCls = classNames(
+    'at-search-bar',
+    {
+      'at-search-bar--fixed': fixed
+    },
+    className
+  )
+  const placeholderWrapStyle: React.CSSProperties = {}
+  const actionStyle: React.CSSProperties = {}
+  if (isFocus || (!isFocus && value)) {
+    actionStyle.opacity = 1
+    actionStyle.marginRight = `0`
+    placeholderWrapStyle.flexGrow = 0
+  } else if (!isFocus && !value) {
+    placeholderWrapStyle.flexGrow = 1
+    actionStyle.opacity = 0
+    actionStyle.marginRight = `-${
+      (actionName.length + 1) * fontSize + fontSize / 2 + 10
+    }px`
+  }
+  if (showActionButton) {
+    actionStyle.opacity = 1
+    actionStyle.marginRight = `0`
   }
 
-  public render(): JSX.Element {
-    const {
-      value,
-      placeholder,
-      maxLength,
-      fixed,
-      disabled,
-      showActionButton,
-      actionName = '搜索',
-      inputType, // 处理issue#464
-      className,
-      customStyle,
-      enableNative
-    } = this.props
-    const { isFocus } = this.state
-    const fontSize = 14
-    const rootCls = classNames(
-      'at-search-bar',
-      {
-        'at-search-bar--fixed': fixed
-      },
-      className
-    )
-    const placeholderWrapStyle: React.CSSProperties = {}
-    const actionStyle: React.CSSProperties = {}
-    if (isFocus || (!isFocus && value)) {
-      actionStyle.opacity = 1
-      actionStyle.marginRight = `0`
-      placeholderWrapStyle.flexGrow = 0
-    } else if (!isFocus && !value) {
-      placeholderWrapStyle.flexGrow = 1
-      actionStyle.opacity = 0
-      actionStyle.marginRight = `-${
-        (actionName.length + 1) * fontSize + fontSize / 2 + 10
-      }px`
-    }
-    if (showActionButton) {
-      actionStyle.opacity = 1
-      actionStyle.marginRight = `0`
-    }
+  const clearIconStyle: React.CSSProperties = { display: 'flex' }
+  const placeholderStyle: React.CSSProperties = { visibility: 'hidden' }
+  if (!value.length) {
+    clearIconStyle.display = 'none'
+    placeholderStyle.visibility = 'visible'
+  }
 
-    const clearIconStyle: React.CSSProperties = { display: 'flex' }
-    const placeholderStyle: React.CSSProperties = { visibility: 'hidden' }
-    if (!value.length) {
-      clearIconStyle.display = 'none'
-      placeholderStyle.visibility = 'visible'
-    }
-
-    return (
-      <View className={rootCls} style={customStyle}>
-        <View className='at-search-bar__input-cnt'>
-          <View
-            className='at-search-bar__placeholder-wrap'
-            style={placeholderWrapStyle}
-          >
-            <Text className='at-icon at-icon-search'></Text>
-            <Text
-              className='at-search-bar__placeholder'
-              style={placeholderStyle}
-            >
-              {isFocus ? '' : placeholder}
-            </Text>
-          </View>
-          <Input
-            className='at-search-bar__input'
-            type={inputType}
-            confirmType='search'
-            value={value}
-            focus={isFocus}
-            disabled={disabled}
-            maxlength={maxLength}
-            // @ts-ignore ci 上面这个检查不通过, 暂时跳过ts检查
-            enableNative={enableNative}
-            onInput={this.handleChange}
-            onFocus={this.handleFocus}
-            onBlur={this.handleBlur}
-            onConfirm={this.handleConfirm}
-          />
-          <View
-            className='at-search-bar__clear'
-            style={clearIconStyle}
-            onTouchStart={this.handleClear}
-          >
-            <Text className='at-icon at-icon-close-circle'></Text>
-          </View>
-        </View>
+  return (
+    <View className={rootCls} style={customStyle}>
+      <View className='at-search-bar__input-cnt'>
         <View
-          className='at-search-bar__action'
-          style={actionStyle}
-          onClick={this.handleActionClick}
+          className='at-search-bar__placeholder-wrap'
+          style={placeholderWrapStyle}
         >
-          {actionName}
+          <Text className='at-icon at-icon-search'></Text>
+          <Text className='at-search-bar__placeholder' style={placeholderStyle}>
+            {isFocus ? '' : placeholder}
+          </Text>
+        </View>
+        <Input
+          className='at-search-bar__input'
+          type={inputType}
+          confirmType='search'
+          value={value}
+          focus={isFocus}
+          disabled={disabled}
+          maxlength={maxLength}
+          // @ts-ignore ci 上面这个检查不通过, 暂时跳过ts检查
+          enableNative={enableNative}
+          onInput={handleChange}
+          onFocus={handleFocus}
+          onBlur={handleBlur}
+          onConfirm={handleConfirm}
+        />
+        <View
+          className='at-search-bar__clear'
+          style={clearIconStyle}
+          onTouchStart={handleClear}
+        >
+          <Text className='at-icon at-icon-close-circle'></Text>
         </View>
       </View>
-    )
-  }
-}
-
-AtSearchBar.defaultProps = {
-  value: '',
-  placeholder: '搜索',
-  maxLength: 140,
-  fixed: false,
-  focus: false,
-  disabled: false,
-  showActionButton: false,
-  actionName: '搜索',
-  inputType: 'text',
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  onChange: (): void => {},
-  enableNative: true
+      <View
+        className='at-search-bar__action'
+        style={actionStyle}
+        onClick={handleActionClick}
+      >
+        {actionName}
+      </View>
+    </View>
+  )
 }
 
 AtSearchBar.propTypes = {
@@ -196,3 +164,5 @@ AtSearchBar.propTypes = {
   onClear: PropTypes.func,
   enableNative: PropTypes.bool
 }
+
+export default AtSearchBar

--- a/packages/taro-ui/src/components/segmented-control/index.tsx
+++ b/packages/taro-ui/src/components/segmented-control/index.tsx
@@ -1,85 +1,66 @@
 import classNames from 'classnames'
-import PropTypes, { InferProps } from 'prop-types'
+import PropTypes from 'prop-types'
 import React from 'react'
 import { View } from '@tarojs/components'
 import { CommonEvent } from '@tarojs/components/types/common'
 import { AtSegmentedControlProps } from '../../../types/segmented-control'
-import { mergeStyle, pxTransform } from '../../common/utils'
+import { mergeStyle, noop, pxTransform } from '../../common/utils'
 
-export default class AtSegmentedControl extends React.Component<AtSegmentedControlProps> {
-  public static defaultProps: AtSegmentedControlProps
-  public static propTypes: InferProps<AtSegmentedControlProps>
-
-  private handleClick(index: number, event: CommonEvent): void {
-    if (this.props.disabled) return
-    this.props.onClick(index, event)
+function AtSegmentedControl({
+  customStyle = '',
+  className = '',
+  disabled = false,
+  values = [],
+  selectedColor = '',
+  current = 0,
+  color = '',
+  fontSize = 28,
+  onClick = noop
+}: AtSegmentedControlProps): JSX.Element {
+  const handleClick = (index: number, event: CommonEvent): void => {
+    if (disabled) return
+    onClick(index, event)
   }
 
-  public render(): JSX.Element {
-    const {
-      customStyle = '',
-      className,
-      disabled,
-      values,
-      selectedColor,
-      current,
-      color,
-      fontSize = 28
-    } = this.props
-
-    const rootStyle = {
-      borderColor: selectedColor
-    }
-    const itemStyle = {
-      color: selectedColor,
-      fontSize: pxTransform(fontSize),
-      borderColor: selectedColor,
-      backgroundColor: color
-    }
-    const selectedItemStyle = {
-      color,
-      fontSize: pxTransform(fontSize),
-      borderColor: selectedColor,
-      backgroundColor: selectedColor
-    }
-    const rootCls = classNames(
-      'at-segmented-control',
-      {
-        'at-segmented-control--disabled': disabled
-      },
-      className
-    )
-
-    return (
-      <View className={rootCls} style={mergeStyle(rootStyle, customStyle)}>
-        {values.map((value, i) => (
-          <View
-            className={classNames('at-segmented-control__item', {
-              'at-segmented-control__item--active': current === i
-            })}
-            style={current === i ? selectedItemStyle : itemStyle}
-            key={value}
-            onClick={this.handleClick.bind(this, i)}
-          >
-            {value}
-          </View>
-        ))}
-      </View>
-    )
+  const rootStyle = {
+    borderColor: selectedColor
   }
-}
+  const itemStyle = {
+    color: selectedColor,
+    fontSize: pxTransform(fontSize),
+    borderColor: selectedColor,
+    backgroundColor: color
+  }
+  const selectedItemStyle = {
+    color,
+    fontSize: pxTransform(fontSize),
+    borderColor: selectedColor,
+    backgroundColor: selectedColor
+  }
+  const rootCls = classNames(
+    'at-segmented-control',
+    {
+      'at-segmented-control--disabled': disabled
+    },
+    className
+  )
 
-AtSegmentedControl.defaultProps = {
-  customStyle: '',
-  className: '',
-  current: 0,
-  color: '',
-  fontSize: 28,
-  disabled: false,
-  selectedColor: '',
-  values: [],
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  onClick: (): void => {}
+  return (
+    <View className={rootCls} style={mergeStyle(rootStyle, customStyle)}>
+      {values.map((value, i) => (
+        <View
+          className={classNames('at-segmented-control__item', {
+            'at-segmented-control__item--active': current === i
+          })}
+          style={current === i ? selectedItemStyle : itemStyle}
+          key={value}
+          onClick={event => handleClick(i, event)}
+        >
+          {value}
+        </View>
+      ))}
+    </View>
+  )
 }
 
 AtSegmentedControl.propTypes = {
@@ -92,3 +73,5 @@ AtSegmentedControl.propTypes = {
   values: PropTypes.array,
   onClick: PropTypes.func
 }
+
+export default AtSegmentedControl

--- a/packages/taro-ui/src/components/slider/index.tsx
+++ b/packages/taro-ui/src/components/slider/index.tsx
@@ -1,118 +1,81 @@
 import classNames from 'classnames'
-import PropTypes, { InferProps } from 'prop-types'
-import React from 'react'
+import PropTypes from 'prop-types'
+import React, { useEffect, useState } from 'react'
 import { Slider, View } from '@tarojs/components'
 import { CommonEvent } from '@tarojs/components/types/common'
-import { AtSliderProps, AtSliderState } from '../../../types/slider'
+import { AtSliderProps } from '../../../types/slider'
 
-export default class AtSlider extends React.Component<
-  AtSliderProps,
-  AtSliderState
-> {
-  public static defaultProps: AtSliderProps
-  public static propTypes: InferProps<AtSliderProps>
-
-  public constructor(props: AtSliderProps) {
-    super(props)
-    const { value = 0, min = 0, max = 100 } = props
-    this.state = {
-      _value: AtSlider.clampNumber(value, min, max)
-    }
-  }
-
-  protected static clampNumber(
-    value: number,
-    lower: number,
-    upper: number
-  ): number {
-    return Math.max(lower, Math.min(upper, value))
-  }
-
-  private handleChanging(e: CommonEvent): void {
-    const { _value } = this.state
-    const { value }: { value: number } = e.detail
-
-    if (value !== _value) {
-      this.setState({ _value: value })
-    }
-    this.props.onChanging && this.props.onChanging(value)
-  }
-
-  private handleChange(e: CommonEvent): void {
-    const { value } = e.detail
-
-    this.setState({ _value: value })
-    this.props.onChange && this.props.onChange(value)
-  }
-
-  public UNSAFE_componentWillReceiveProps(props: AtSliderProps): void {
-    const { value = 0, min = 0, max = 100 } = props
-    this.setState({
-      _value: AtSlider.clampNumber(value, min, max)
-    })
-  }
-
-  public render(): JSX.Element {
-    const { _value } = this.state
-    const {
-      customStyle,
-      className,
-      min,
-      max,
-      step,
-      disabled,
-      activeColor,
-      backgroundColor,
-      blockSize,
-      blockColor,
-      showValue
-    } = this.props
-
-    return (
-      <View
-        className={classNames(
-          {
-            'at-slider': true,
-            'at-slider--disabled': disabled
-          },
-          className
-        )}
-        style={customStyle}
-      >
-        <View className='at-slider__inner'>
-          <Slider
-            min={min}
-            max={max}
-            step={step}
-            value={_value}
-            disabled={disabled}
-            activeColor={activeColor}
-            backgroundColor={backgroundColor}
-            blockSize={blockSize}
-            blockColor={blockColor}
-            onChanging={this.handleChanging.bind(this)}
-            onChange={this.handleChange.bind(this)}
-          ></Slider>
-        </View>
-        {showValue && <View className='at-slider__text'>{`${_value}`}</View>}
-      </View>
-    )
-  }
+function clampNumber(value: number, lower: number, upper: number): number {
+  return Math.max(lower, Math.min(upper, value))
 }
 
-AtSlider.defaultProps = {
-  customStyle: '',
-  className: '',
-  min: 0,
-  max: 100,
-  step: 1,
-  value: 0,
-  disabled: false,
-  activeColor: '#6190e8',
-  backgroundColor: '#e9e9e9',
-  blockSize: 28,
-  blockColor: '#ffffff',
-  showValue: false
+function AtSlider({
+  customStyle = '',
+  className = '',
+  min = 0,
+  max = 100,
+  step = 1,
+  value = 0,
+  disabled = false,
+  activeColor = '#6190e8',
+  backgroundColor = '#e9e9e9',
+  blockSize = 28,
+  blockColor = '#ffffff',
+  showValue = false,
+  onChange,
+  onChanging
+}: AtSliderProps): JSX.Element {
+  const [_value, setValue] = useState(() => clampNumber(value, min, max))
+
+  useEffect(() => {
+    setValue(clampNumber(value, min, max))
+  }, [value, min, max])
+
+  const handleChanging = (e: CommonEvent): void => {
+    const { value: detailValue }: { value: number } = e.detail
+
+    if (detailValue !== _value) {
+      setValue(detailValue)
+    }
+    onChanging && onChanging(detailValue)
+  }
+
+  const handleChange = (e: CommonEvent): void => {
+    const { value: detailValue } = e.detail
+
+    setValue(detailValue)
+    onChange && onChange(detailValue)
+  }
+
+  return (
+    <View
+      className={classNames(
+        {
+          'at-slider': true,
+          'at-slider--disabled': disabled
+        },
+        className
+      )}
+      style={customStyle}
+    >
+      <View className='at-slider__inner'>
+        <Slider
+          min={min}
+          max={max}
+          step={step}
+          value={_value}
+          disabled={disabled}
+          activeColor={activeColor}
+          backgroundColor={backgroundColor}
+          blockSize={blockSize}
+          blockColor={blockColor}
+          onChanging={handleChanging}
+          onChange={handleChange}
+        ></Slider>
+      </View>
+      {showValue && <View className='at-slider__text'>{`${_value}`}</View>}
+    </View>
+  )
 }
 
 AtSlider.propTypes = {
@@ -131,3 +94,5 @@ AtSlider.propTypes = {
   onChange: PropTypes.func,
   onChanging: PropTypes.func
 }
+
+export default AtSlider

--- a/packages/taro-ui/src/components/steps/index.tsx
+++ b/packages/taro-ui/src/components/steps/index.tsx
@@ -1,82 +1,72 @@
 import classNames from 'classnames'
-import PropTypes, { InferProps } from 'prop-types'
+import PropTypes from 'prop-types'
 import React from 'react'
 import { Text, View } from '@tarojs/components'
 import { CommonEvent } from '@tarojs/components/types/common'
 import { AtStepsProps } from '../../../types/steps'
+import { noop } from '../../common/utils'
 
-export default class AtSteps extends React.Component<AtStepsProps> {
-  public static defaultProps: AtStepsProps
-  public static propTypes: InferProps<AtStepsProps>
-
-  private handleClick(current: number, event: CommonEvent): void {
-    this.props.onChange(current, event)
+export default function AtSteps({
+  customStyle = '',
+  className = '',
+  current = 0,
+  items = [],
+  onChange = noop
+}: AtStepsProps): JSX.Element {
+  const handleClick = (stepCurrent: number, event: CommonEvent): void => {
+    onChange(stepCurrent, event)
   }
 
-  public render(): JSX.Element {
-    const { customStyle, className, items, current } = this.props
-
-    return (
-      <View className={classNames('at-steps', className)} style={customStyle}>
-        {!!items &&
-          items.map((item, i) => (
-            <View
-              key={item.title}
-              className={classNames({
-                'at-steps__item': true,
-                'at-steps__item--active': i === current,
-                'at-steps__item--inactive': i !== current
-              })}
-              onClick={this.handleClick.bind(this, i)}
-            >
-              <View className='at-steps__circular-wrap'>
-                {i !== 0 && <View className='at-steps__left-line'></View>}
-                {item.status ? (
-                  <View
-                    className={classNames({
-                      'at-icon': true,
-                      'at-icon-check-circle': item.status === 'success',
-                      'at-icon-close-circle': item.status === 'error',
-                      'at-steps__single-icon': true,
-                      'at-steps__single-icon--success':
-                        item.status === 'success',
-                      'at-steps__single-icon--error': item.status === 'error'
-                    })}
-                  ></View>
-                ) : (
-                  <View className='at-steps__circular'>
-                    {item.icon ? (
-                      <Text
-                        className={classNames('at-icon', {
-                          [`at-icon-${item.icon.value}`]: item.icon.value,
-                          'at-steps__circle-icon': true
-                        })}
-                      ></Text>
-                    ) : (
-                      <Text className='at-steps__num'>{i + 1}</Text>
-                    )}
-                  </View>
-                )}
-                {i !== items.length - 1 && (
-                  <View className='at-steps__right-line'></View>
-                )}
-              </View>
-              <View className='at-steps__title'>{item.title}</View>
-              <View className='at-steps__desc'>{item.desc}</View>
+  return (
+    <View className={classNames('at-steps', className)} style={customStyle}>
+      {!!items &&
+        items.map((item, i) => (
+          <View
+            key={item.title}
+            className={classNames({
+              'at-steps__item': true,
+              'at-steps__item--active': i === current,
+              'at-steps__item--inactive': i !== current
+            })}
+            onClick={event => handleClick(i, event)}
+          >
+            <View className='at-steps__circular-wrap'>
+              {i !== 0 && <View className='at-steps__left-line'></View>}
+              {item.status ? (
+                <View
+                  className={classNames({
+                    'at-icon': true,
+                    'at-icon-check-circle': item.status === 'success',
+                    'at-icon-close-circle': item.status === 'error',
+                    'at-steps__single-icon': true,
+                    'at-steps__single-icon--success': item.status === 'success',
+                    'at-steps__single-icon--error': item.status === 'error'
+                  })}
+                ></View>
+              ) : (
+                <View className='at-steps__circular'>
+                  {item.icon ? (
+                    <Text
+                      className={classNames('at-icon', {
+                        [`at-icon-${item.icon.value}`]: item.icon.value,
+                        'at-steps__circle-icon': true
+                      })}
+                    ></Text>
+                  ) : (
+                    <Text className='at-steps__num'>{i + 1}</Text>
+                  )}
+                </View>
+              )}
+              {i !== items.length - 1 && (
+                <View className='at-steps__right-line'></View>
+              )}
             </View>
-          ))}
-      </View>
-    )
-  }
-}
-
-AtSteps.defaultProps = {
-  customStyle: '',
-  className: '',
-  current: 0,
-  items: [],
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  onChange: (): void => {}
+            <View className='at-steps__title'>{item.title}</View>
+            <View className='at-steps__desc'>{item.desc}</View>
+          </View>
+        ))}
+    </View>
+  )
 }
 
 AtSteps.propTypes = {

--- a/packages/taro-ui/src/components/swipe-action/index.tsx
+++ b/packages/taro-ui/src/components/swipe-action/index.tsx
@@ -72,10 +72,10 @@ const AtSwipeAction = forwardRef<AtSwipeActionInstance, AtSwipeActionProps>(
           }
         } else {
           const currentMoveX = moveXRef.current
+          setIsOpened(false)
           setOffsetSize(currentMoveX)
           setTimeout(() => {
             setOffsetSize(0)
-            setIsOpened(false)
           }, 0)
         }
       },

--- a/packages/taro-ui/src/components/swipe-action/index.tsx
+++ b/packages/taro-ui/src/components/swipe-action/index.tsx
@@ -1,6 +1,13 @@
 import classNames from 'classnames'
-import PropTypes, { InferProps } from 'prop-types'
-import React from 'react'
+import PropTypes from 'prop-types'
+import React, {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState
+} from 'react'
 import Taro from '@tarojs/taro'
 import { Text, View, MovableArea, MovableView } from '@tarojs/components'
 import { CommonEvent } from '@tarojs/components/types/common'
@@ -12,158 +19,156 @@ import {
 import { uuid, delayGetClientRect } from '../../common/utils'
 import AtSwipeActionOptions from './options/index'
 
-export default class AtSwipeAction extends React.Component<
-  AtSwipeActionProps,
-  AtSwipeActionState
-> {
-  public static defaultProps: AtSwipeActionProps
-  public static propTypes: InferProps<AtSwipeActionProps>
+export type AtSwipeActionInstance = {
+  state: AtSwipeActionState
+  onChange: (e: { detail: { x: number } }) => void
+  onTouchEnd: (e: CommonEvent) => void
+}
 
-  private moveX: number
+const AtSwipeAction = forwardRef<AtSwipeActionInstance, AtSwipeActionProps>(
+  function AtSwipeAction(
+    {
+      options = [],
+      isOpened = false,
+      disabled = false,
+      autoClose = false,
+      className,
+      children,
+      onClick,
+      onOpened,
+      onClosed
+    },
+    ref
+  ): JSX.Element {
+    const [componentId] = useState(() => uuid())
+    const [offsetSize, setOffsetSize] = useState(0)
+    const [_isOpened, setIsOpened] = useState(!!isOpened)
+    const [eleWidth, setEleWidth] = useState(0)
+    const [maxOffsetSize, setMaxOffsetSize] = useState(0)
+    const moveXRef = useRef(offsetSize)
 
-  public constructor(props: AtSwipeActionProps) {
-    super(props)
-    const { isOpened } = props
-    this.state = {
-      componentId: uuid(),
-      // eslint-disable-next-line no-extra-boolean-cast
-      offsetSize: 0,
-      _isOpened: !!isOpened,
+    const getMaxOffsetSize = useCallback(async (): Promise<void> => {
+      const actionOptionsRect = await delayGetClientRect({
+        selectorStr: `#swipeActionOptions-${componentId}`
+      })
+
+      setMaxOffsetSize(actionOptionsRect[0].width)
+    }, [componentId])
+
+    const getAreaWidth = useCallback(async (): Promise<void> => {
+      const systemInfo = await Taro.getSystemInfo()
+      setEleWidth(systemInfo.windowWidth)
+    }, [])
+
+    const _reset = useCallback(
+      (opened: boolean): void => {
+        if (opened) {
+          if (process.env.TARO_ENV === 'jd') {
+            setIsOpened(true)
+            setOffsetSize(-maxOffsetSize + 0.01)
+          } else {
+            setIsOpened(true)
+            setOffsetSize(-maxOffsetSize)
+          }
+        } else {
+          setOffsetSize(moveXRef.current)
+          setOffsetSize(0)
+          setIsOpened(false)
+        }
+      },
+      [maxOffsetSize]
+    )
+
+    useEffect(() => {
+      getAreaWidth()
+    }, [getAreaWidth])
+
+    useEffect(() => {
+      if (eleWidth > 0) {
+        getMaxOffsetSize()
+      }
+    }, [eleWidth, getMaxOffsetSize])
+
+    const isOpenedPropRef = useRef(isOpened)
+    useEffect(() => {
+      if (isOpenedPropRef.current === isOpened) return
+      isOpenedPropRef.current = isOpened
+      if (isOpened !== _isOpened) {
+        moveXRef.current = isOpened ? 0 : maxOffsetSize
+        _reset(!!isOpened)
+      }
+    }, [isOpened, _isOpened, maxOffsetSize, _reset])
+
+    const handleOpened = (event: CommonEvent): void => {
+      if (typeof onOpened === 'function') {
+        onOpened(event)
+      }
+    }
+
+    const handleClosed = (event: CommonEvent): void => {
+      if (typeof onClosed === 'function') {
+        onClosed(event)
+      }
+    }
+
+    const handleClick = (
+      item: SwipeActionOption,
+      index: number,
+      event: CommonEvent
+    ): void => {
+      if (typeof onClick === 'function') {
+        onClick(item, index, event)
+      }
+      if (autoClose) {
+        _reset(false)
+        handleClosed(event)
+      }
+    }
+
+    const onTouchEnd = (e: CommonEvent): void => {
+      if (Math.abs(moveXRef.current) < maxOffsetSize / 2) {
+        _reset(false)
+        handleClosed(e)
+      } else {
+        _reset(true)
+        handleOpened(e)
+      }
+    }
+
+    const onChange = (e: { detail: { x: number } }): void => {
+      moveXRef.current = e.detail.x
+    }
+
+    const stateRef = useRef<AtSwipeActionState>({
+      componentId,
+      offsetSize,
+      _isOpened,
       needAnimation: false,
-      eleWidth: 0,
-      maxOffsetSize: 0
-    }
-    this.moveX = this.state.offsetSize
-  }
-
-  public componentDidMount(): void {
-    this.getAreaWidth()
-  }
-
-  // 当 eleWidth 发生变化时，需要重新计算 maxOffsetSize
-  public componentDidUpdate(_, prevState: AtSwipeActionState): void {
-    const { eleWidth } = this.state
-    if (prevState.eleWidth !== eleWidth) {
-      this.getMaxOffsetSize()
-    }
-  }
-
-  public UNSAFE_componentWillReceiveProps(nextProps: AtSwipeActionProps): void {
-    const { isOpened } = nextProps
-    const { _isOpened, maxOffsetSize } = this.state
-
-    if (isOpened !== _isOpened) {
-      this.moveX = isOpened ? 0 : maxOffsetSize
-      this._reset(!!isOpened) // TODO: Check behavior
-    }
-  }
-
-  /**
-   * 获取滑动区域宽度
-   */
-  private async getAreaWidth(): Promise<void> {
-    const systemInfo = await Taro.getSystemInfo()
-    this.setState({
-      eleWidth: systemInfo.windowWidth
-    })
-  }
-
-  /**
-   * 获取最大偏移量
-   */
-  private async getMaxOffsetSize(): Promise<void> {
-    const { componentId } = this.state
-
-    const actionOptionsRect = await delayGetClientRect({
-      selectorStr: `#swipeActionOptions-${componentId}`
-    })
-
-    const maxOffsetSize = actionOptionsRect[0].width
-
-    this.setState({
+      eleWidth,
       maxOffsetSize
     })
-  }
+    stateRef.current = {
+      componentId,
+      offsetSize,
+      _isOpened,
+      needAnimation: false,
+      eleWidth,
+      maxOffsetSize
+    }
 
-  private _reset(isOpened: boolean): void {
-    if (isOpened) {
-      const { maxOffsetSize } = this.state
-      if (process.env.TARO_ENV === 'jd') {
-        this.setState({
-          _isOpened: true,
-          offsetSize: -maxOffsetSize + 0.01
-        })
-      } else {
-        this.setState({
-          _isOpened: true,
-          offsetSize: -maxOffsetSize
-        })
-      }
-    } else {
-      this.setState(
-        {
-          offsetSize: this.moveX
+    useImperativeHandle(
+      ref,
+      () => ({
+        get state() {
+          return stateRef.current
         },
-        () => {
-          this.setState({
-            offsetSize: 0,
-            _isOpened: false
-          })
-        }
-      )
-    }
-  }
+        onChange,
+        onTouchEnd
+      }),
+      [onChange, onTouchEnd]
+    )
 
-  private handleOpened = (event: CommonEvent): void => {
-    const { onOpened } = this.props
-    if (typeof onOpened === 'function') {
-      onOpened(event)
-    }
-  }
-
-  private handleClosed = (event: CommonEvent): void => {
-    const { onClosed } = this.props
-    if (typeof onClosed === 'function') {
-      onClosed(event)
-    }
-  }
-
-  private handleClick = (
-    item: SwipeActionOption,
-    index: number,
-    event: CommonEvent
-  ): void => {
-    const { onClick, autoClose } = this.props
-
-    if (typeof onClick === 'function') {
-      onClick(item, index, event)
-    }
-    if (autoClose) {
-      this._reset(false) // TODO: Check behavior
-      this.handleClosed(event)
-    }
-  }
-
-  onTouchEnd = e => {
-    const { maxOffsetSize } = this.state
-    if (Math.abs(this.moveX) < maxOffsetSize / 2) {
-      this._reset(false)
-      this.handleClosed(e)
-    } else {
-      this._reset(true)
-      this.handleOpened(e)
-    }
-  }
-
-  onChange = e => {
-    this.moveX = e.detail.x
-  }
-
-  public render(): JSX.Element {
-    const { componentId, maxOffsetSize, eleWidth, offsetSize } = this.state
-
-    const { options, disabled } = this.props
-    const rootClass = classNames('at-swipe-action', this.props.className)
+    const rootClass = classNames('at-swipe-action', className)
 
     return (
       <View
@@ -184,14 +189,14 @@ export default class AtSwipeAction extends React.Component<
             direction='horizontal'
             damping={50}
             x={offsetSize}
-            onTouchEnd={this.onTouchEnd}
-            onChange={this.onChange}
+            onTouchEnd={onTouchEnd}
+            onChange={onChange}
             disabled={disabled}
             style={{
               width: `${eleWidth + maxOffsetSize}px`
             }}
           >
-            {this.props.children}
+            {children}
             {Array.isArray(options) && options.length > 0 ? (
               <AtSwipeActionOptions
                 options={options}
@@ -204,7 +209,7 @@ export default class AtSwipeAction extends React.Component<
                   <View
                     key={`${item.text}-${key}`}
                     style={item.style}
-                    onClick={(e): void => this.handleClick(item, key, e)}
+                    onClick={(e): void => handleClick(item, key, e)}
                     className={classNames(
                       'at-swipe-action__option',
                       item.className
@@ -220,18 +225,10 @@ export default class AtSwipeAction extends React.Component<
       </View>
     )
   }
-}
+)
 
-AtSwipeAction.defaultProps = {
-  options: [],
-  isOpened: false,
-  disabled: false,
-  autoClose: false,
-  maxDistance: 0,
-  areaWidth: 0
-}
-
-AtSwipeAction.propTypes = {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+;(AtSwipeAction as any).propTypes = {
   isOpened: PropTypes.bool,
   disabled: PropTypes.bool,
   autoClose: PropTypes.bool,
@@ -251,3 +248,5 @@ AtSwipeAction.propTypes = {
   onOpened: PropTypes.func,
   onClosed: PropTypes.func
 }
+
+export default AtSwipeAction

--- a/packages/taro-ui/src/components/swipe-action/index.tsx
+++ b/packages/taro-ui/src/components/swipe-action/index.tsx
@@ -71,9 +71,12 @@ const AtSwipeAction = forwardRef<AtSwipeActionInstance, AtSwipeActionProps>(
             setOffsetSize(-maxOffsetSize)
           }
         } else {
-          setOffsetSize(moveXRef.current)
-          setOffsetSize(0)
-          setIsOpened(false)
+          const currentMoveX = moveXRef.current
+          setOffsetSize(currentMoveX)
+          setTimeout(() => {
+            setOffsetSize(0)
+            setIsOpened(false)
+          }, 0)
         }
       },
       [maxOffsetSize]

--- a/packages/taro-ui/src/components/swipe-action/options/index.tsx
+++ b/packages/taro-ui/src/components/swipe-action/options/index.tsx
@@ -3,21 +3,23 @@ import React from 'react'
 import { View } from '@tarojs/components'
 import { AtSwipeActionOptionsProps } from '../../../../types/swipe-action'
 
-export default class AtSwipeActionOptions extends React.Component<AtSwipeActionOptionsProps> {
-  public render(): JSX.Element {
-    const rootClass = classNames(
-      'at-swipe-action__options',
-      this.props.className
-    )
+function AtSwipeActionOptions({
+  className,
+  componentId,
+  customStyle,
+  children
+}: AtSwipeActionOptionsProps): JSX.Element {
+  const rootClass = classNames('at-swipe-action__options', className)
 
-    return (
-      <View
-        id={`swipeActionOptions-${this.props.componentId}`}
-        className={rootClass}
-        style={this.props.customStyle}
-      >
-        {this.props.children}
-      </View>
-    )
-  }
+  return (
+    <View
+      id={`swipeActionOptions-${componentId}`}
+      className={rootClass}
+      style={customStyle}
+    >
+      {children}
+    </View>
+  )
 }
+
+export default AtSwipeActionOptions

--- a/packages/taro-ui/src/components/switch/index.tsx
+++ b/packages/taro-ui/src/components/switch/index.tsx
@@ -1,60 +1,51 @@
 import classNames from 'classnames'
-import PropTypes, { InferProps } from 'prop-types'
+import PropTypes from 'prop-types'
 import React from 'react'
 import { Switch, View } from '@tarojs/components'
 import { CommonEvent } from '@tarojs/components/types/common'
 import { AtSwitchProps } from '../../../types/switch'
 
-export default class AtSwitch extends React.Component<AtSwitchProps> {
-  public static defaultProps: AtSwitchProps
-  public static propTypes: InferProps<AtSwitchProps>
-
-  private handleChange = (event: CommonEvent): void => {
-    const { value, checked } = event.detail
-    const state = typeof value === 'undefined' ? checked : value
-    this.props.onChange && this.props.onChange(state)
+function AtSwitch({
+  customStyle = '',
+  className = '',
+  title = '',
+  color = '#6190e8',
+  border = true,
+  disabled = false,
+  checked = false,
+  onChange
+}: AtSwitchProps): JSX.Element {
+  const handleChange = (event: CommonEvent): void => {
+    const { value, checked: eventChecked } = event.detail
+    const state = typeof value === 'undefined' ? eventChecked : value
+    onChange && onChange(state)
   }
 
-  public render(): JSX.Element {
-    const { customStyle, className, disabled, border, title, checked, color } =
-      this.props
+  const rootCls = classNames(
+    'at-switch',
+    {
+      'at-switch--without-border': !border
+    },
+    className
+  )
+  const containerCls = classNames('at-switch__container', {
+    'at-switch--disabled': disabled
+  })
 
-    const rootCls = classNames(
-      'at-switch',
-      {
-        'at-switch--without-border': !border
-      },
-      className
-    )
-    const containerCls = classNames('at-switch__container', {
-      'at-switch--disabled': disabled
-    })
-
-    return (
-      <View className={rootCls} style={customStyle}>
-        <View className='at-switch__title'>{title}</View>
-        <View className={containerCls}>
-          <View className='at-switch__mask'></View>
-          <Switch
-            className='at-switch__switch'
-            checked={checked}
-            color={color}
-            onChange={this.handleChange}
-          />
-        </View>
+  return (
+    <View className={rootCls} style={customStyle}>
+      <View className='at-switch__title'>{title}</View>
+      <View className={containerCls}>
+        <View className='at-switch__mask'></View>
+        <Switch
+          className='at-switch__switch'
+          checked={checked}
+          color={color}
+          onChange={handleChange}
+        />
       </View>
-    )
-  }
-}
-
-AtSwitch.defaultProps = {
-  customStyle: '',
-  className: '',
-  title: '',
-  color: '#6190e8',
-  border: true,
-  disabled: false,
-  checked: false
+    </View>
+  )
 }
 
 AtSwitch.propTypes = {
@@ -67,3 +58,5 @@ AtSwitch.propTypes = {
   disabled: PropTypes.bool,
   onChange: PropTypes.func
 }
+
+export default AtSwitch

--- a/packages/taro-ui/src/components/tab-bar/index.tsx
+++ b/packages/taro-ui/src/components/tab-bar/index.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames'
-import PropTypes, { InferProps } from 'prop-types'
+import PropTypes from 'prop-types'
 import React from 'react'
 import { Image, Text, View } from '@tarojs/components'
 import { CommonEvent } from '@tarojs/components/types/common'
@@ -7,165 +7,129 @@ import { AtTabBarProps, TabItem } from '../../../types/tab-bar'
 import { mergeStyle } from '../../common/utils'
 import AtBadge from '../badge/index'
 
-export default class AtTabBar extends React.Component<AtTabBarProps> {
-  public static defaultProps: AtTabBarProps
-  public static propTypes: InferProps<AtTabBarProps>
-
-  // constructor () {
-  //   super(...arguments)
-  //   this.state = {
-  //     isIPhoneX: false
-  //   }
-  // }
-
-  // componentDidMount () {
-  //   const curEnv = Taro.getEnv()
-
-  //   if (
-  //     curEnv === Taro.ENV_TYPE.WEAPP &&
-  //     Taro.getSystemInfoSync().model.indexOf('iPhone X') >= 0
-  //   ) {
-  //     this.setState({ isIPhoneX: true })
-  //   }
-  // }
-
-  private handleClick(index: number, event: CommonEvent): void {
-    this.props.onClick(index, event)
+function AtTabBar({
+  customStyle = '',
+  className = '',
+  fixed = false,
+  backgroundColor,
+  tabList = [],
+  current = 0,
+  color,
+  iconSize,
+  fontSize,
+  selectedColor,
+  onClick
+}: AtTabBarProps): JSX.Element {
+  const handleClick = (index: number, event: CommonEvent): void => {
+    onClick && onClick(index, event)
   }
 
-  public render(): JSX.Element {
-    const {
-      customStyle = '',
-      className,
-      fixed,
-      backgroundColor,
-      tabList,
-      current,
-      color,
-      iconSize,
-      fontSize,
-      selectedColor
-    } = this.props
-    // const { isIPhoneX } = this.state
-    const defaultStyle = {
-      color: color || ''
-    }
-    const selectedStyle = {
-      color: selectedColor || ''
-    }
-    const titleStyle = {
-      fontSize: fontSize ? `${fontSize}px` : ''
-    }
-    const rootStyle = {
-      backgroundColor: backgroundColor || ''
-    }
-    const imgStyle = {
-      width: `${iconSize}px`,
-      height: `${iconSize}px`
-    }
+  const defaultStyle = {
+    color: color || ''
+  }
+  const selectedStyle = {
+    color: selectedColor || ''
+  }
+  const titleStyle = {
+    fontSize: fontSize ? `${fontSize}px` : ''
+  }
+  const rootStyle = {
+    backgroundColor: backgroundColor || ''
+  }
+  const imgStyle = {
+    width: `${iconSize}px`,
+    height: `${iconSize}px`
+  }
 
-    return (
-      <View
-        className={classNames(
-          {
-            'at-tab-bar': true,
-            'at-tab-bar--fixed': fixed
-            // 'at-tab-bar--ipx': isIPhoneX
-          },
-          className
-        )}
-        style={mergeStyle(rootStyle, customStyle)}
-      >
-        {tabList.map((item: TabItem, i: number) => (
-          <View
-            className={classNames('at-tab-bar__item', {
-              'at-tab-bar__item--active': current === i
-            })}
-            style={current === i ? selectedStyle : defaultStyle}
-            key={i}
-            onClick={this.handleClick.bind(this, i)}
-          >
-            {item.iconType ? (
-              <AtBadge
-                dot={!!item.dot}
-                value={item.text}
-                maxValue={Number(item.max)}
-              >
-                <View className='at-tab-bar__icon'>
-                  <Text
-                    className={classNames(
-                      `${item.iconPrefixClass || 'at-icon'}`,
-                      {
-                        [`${item.iconPrefixClass || 'at-icon'}-${
-                          item.selectedIconType
-                        }`]: current === i && item.selectedIconType,
-                        [`${item.iconPrefixClass || 'at-icon'}-${
-                          item.iconType
-                        }`]: !(current === i && item.selectedIconType)
-                      }
-                    )}
-                    style={{
-                      color: current === i ? selectedColor : color,
-                      fontSize: iconSize ? `${iconSize}px` : ''
-                    }}
-                  ></Text>
-                </View>
-              </AtBadge>
-            ) : null}
+  return (
+    <View
+      className={classNames(
+        {
+          'at-tab-bar': true,
+          'at-tab-bar--fixed': fixed
+        },
+        className
+      )}
+      style={mergeStyle(rootStyle, customStyle)}
+    >
+      {tabList.map((item: TabItem, i: number) => (
+        <View
+          className={classNames('at-tab-bar__item', {
+            'at-tab-bar__item--active': current === i
+          })}
+          style={current === i ? selectedStyle : defaultStyle}
+          key={i}
+          onClick={(event: CommonEvent) => handleClick(i, event)}
+        >
+          {item.iconType ? (
+            <AtBadge
+              dot={!!item.dot}
+              value={item.text}
+              maxValue={Number(item.max)}
+            >
+              <View className='at-tab-bar__icon'>
+                <Text
+                  className={classNames(
+                    `${item.iconPrefixClass || 'at-icon'}`,
+                    {
+                      [`${item.iconPrefixClass || 'at-icon'}-${
+                        item.selectedIconType
+                      }`]: current === i && item.selectedIconType,
+                      [`${item.iconPrefixClass || 'at-icon'}-${item.iconType}`]:
+                        !(current === i && item.selectedIconType)
+                    }
+                  )}
+                  style={{
+                    color: current === i ? selectedColor : color,
+                    fontSize: iconSize ? `${iconSize}px` : ''
+                  }}
+                ></Text>
+              </View>
+            </AtBadge>
+          ) : null}
 
-            {item.image ? (
-              <AtBadge
-                dot={!!item.dot}
-                value={item.text}
-                maxValue={Number(item.max)}
-              >
-                <View className='at-tab-bar__icon'>
-                  <Image
-                    className={classNames('at-tab-bar__inner-img', {
-                      'at-tab-bar__inner-img--inactive': current !== i
-                    })}
-                    mode='widthFix'
-                    src={item.selectedImage || item.image}
-                    style={imgStyle}
-                  ></Image>
-                  <Image
-                    className={classNames('at-tab-bar__inner-img', {
-                      'at-tab-bar__inner-img--inactive': current === i
-                    })}
-                    mode='widthFix'
-                    src={item.image}
-                    style={imgStyle}
-                  ></Image>
-                </View>
-              </AtBadge>
-            ) : null}
+          {item.image ? (
+            <AtBadge
+              dot={!!item.dot}
+              value={item.text}
+              maxValue={Number(item.max)}
+            >
+              <View className='at-tab-bar__icon'>
+                <Image
+                  className={classNames('at-tab-bar__inner-img', {
+                    'at-tab-bar__inner-img--inactive': current !== i
+                  })}
+                  mode='widthFix'
+                  src={item.selectedImage || item.image}
+                  style={imgStyle}
+                ></Image>
+                <Image
+                  className={classNames('at-tab-bar__inner-img', {
+                    'at-tab-bar__inner-img--inactive': current === i
+                  })}
+                  mode='widthFix'
+                  src={item.image}
+                  style={imgStyle}
+                ></Image>
+              </View>
+            </AtBadge>
+          ) : null}
 
-            <View>
-              <AtBadge
-                dot={item.iconType || item.image ? false : !!item.dot}
-                value={item.iconType || item.image ? '' : item.text}
-                maxValue={item.iconType || item.image ? 0 : Number(item.max)}
-              >
-                <View className='at-tab-bar__title' style={titleStyle}>
-                  {item.title}
-                </View>
-              </AtBadge>
-            </View>
+          <View>
+            <AtBadge
+              dot={item.iconType || item.image ? false : !!item.dot}
+              value={item.iconType || item.image ? '' : item.text}
+              maxValue={item.iconType || item.image ? 0 : Number(item.max)}
+            >
+              <View className='at-tab-bar__title' style={titleStyle}>
+                {item.title}
+              </View>
+            </AtBadge>
           </View>
-        ))}
-      </View>
-    )
-  }
-}
-
-AtTabBar.defaultProps = {
-  customStyle: '',
-  className: '',
-  fixed: false,
-  current: 0,
-  tabList: [],
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  onClick: (): void => {}
+        </View>
+      ))}
+    </View>
+  )
 }
 
 AtTabBar.propTypes = {
@@ -181,3 +145,5 @@ AtTabBar.propTypes = {
   tabList: PropTypes.array,
   onClick: PropTypes.func
 }
+
+export default AtTabBar

--- a/packages/taro-ui/src/components/tabs-pane/index.tsx
+++ b/packages/taro-ui/src/components/tabs-pane/index.tsx
@@ -1,41 +1,33 @@
 import classNames from 'classnames'
-import PropTypes, { InferProps } from 'prop-types'
+import PropTypes from 'prop-types'
 import React from 'react'
 import { View } from '@tarojs/components'
 import { AtTabsPaneProps } from '../../../types/tabs-pane'
 
-export default class AtTabsPane extends React.Component<AtTabsPaneProps> {
-  public static defaultProps: AtTabsPaneProps
-  public static propTypes: InferProps<AtTabsPaneProps>
-
-  public render(): JSX.Element {
-    const { customStyle, className, tabDirection, index, current } = this.props
-
-    return (
-      <View
-        className={classNames(
-          {
-            'at-tabs-pane': true,
-            'at-tabs-pane--vertical': tabDirection === 'vertical',
-            'at-tabs-pane--active': index === current,
-            'at-tabs-pane--inactive': index !== current
-          },
-          className
-        )}
-        style={customStyle}
-      >
-        {this.props.children}
-      </View>
-    )
-  }
-}
-
-AtTabsPane.defaultProps = {
-  customStyle: '',
-  className: '',
-  tabDirection: 'horizontal',
-  index: 0,
-  current: 0
+function AtTabsPane({
+  customStyle = '',
+  className = '',
+  tabDirection = 'horizontal',
+  index = 0,
+  current = 0,
+  children
+}: AtTabsPaneProps): JSX.Element {
+  return (
+    <View
+      className={classNames(
+        {
+          'at-tabs-pane': true,
+          'at-tabs-pane--vertical': tabDirection === 'vertical',
+          'at-tabs-pane--active': index === current,
+          'at-tabs-pane--inactive': index !== current
+        },
+        className
+      )}
+      style={customStyle}
+    >
+      {children}
+    </View>
+  )
 }
 
 AtTabsPane.propTypes = {
@@ -45,3 +37,5 @@ AtTabsPane.propTypes = {
   index: PropTypes.number,
   current: PropTypes.number
 }
+
+export default AtTabsPane

--- a/packages/taro-ui/src/components/tabs/index.tsx
+++ b/packages/taro-ui/src/components/tabs/index.tsx
@@ -1,66 +1,70 @@
 import classNames from 'classnames'
-import PropTypes, { InferProps } from 'prop-types'
-import React from 'react'
+import PropTypes from 'prop-types'
+import React, { useEffect, useRef, useState } from 'react'
 import { ScrollView, View } from '@tarojs/components'
 import { CommonEvent, ITouchEvent } from '@tarojs/components/types/common'
 import Taro from '@tarojs/taro'
-import { AtTabsProps, AtTabsState } from '../../../types/tabs'
+import { AtTabsProps } from '../../../types/tabs'
 import { isTest, mergeStyle, uuid } from '../../common/utils'
 
 const ENV = Taro.getEnv()
 const MIN_DISTANCE = 100
 const MAX_INTERVAL = 10
 
-export default class AtTabs extends React.Component<AtTabsProps, AtTabsState> {
-  public static defaultProps: AtTabsProps
-  public static propTypes: InferProps<AtTabsProps>
+function AtTabs({
+  customStyle = '',
+  className = '',
+  tabDirection = 'horizontal',
+  height = '',
+  current = 0,
+  swipeable = true,
+  scroll = false,
+  animated = true,
+  tabList = [],
+  onClick,
+  children
+}: AtTabsProps): JSX.Element {
+  const tabIdRef = useRef(isTest() ? 'tabs-AOTU2018' : uuid())
+  const touchDotRef = useRef(0)
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const intervalRef = useRef(0)
+  const isMovingRef = useRef(false)
+  const tabHeaderRef = useRef<any>(null)
 
-  private _tabId: string
-  private _touchDot: number
-  private _timer: ReturnType<typeof setInterval> | null
-  private _interval: number
-  private _isMoving: boolean
-  private tabHeaderRef: any
+  const [scrollState, setScrollState] = useState({
+    _scrollLeft: 0,
+    _scrollTop: 0,
+    _scrollIntoView: ''
+  })
 
-  public constructor(props: AtTabsProps) {
-    super(props)
-    this.state = {
-      _scrollLeft: 0,
-      _scrollTop: 0,
-      _scrollIntoView: ''
+  const getTabHeaderRef = (): void => {
+    if (ENV === Taro.ENV_TYPE.WEB) {
+      tabHeaderRef.current = document.getElementById(tabIdRef.current)
     }
-    this._tabId = isTest() ? 'tabs-AOTU2018' : uuid()
-    // 触摸时的原点
-    this._touchDot = 0
-    // 定时器
-    this._timer = null
-    // 滑动时间间隔
-    this._interval = 0
-    // 是否已经在滑动
-    this._isMoving = false
   }
 
-  private updateState = (idx: number): void => {
-    if (this.props.scroll) {
-      // 标签栏滚动
+  const updateState = (idx: number): void => {
+    if (scroll) {
       switch (ENV) {
         case Taro.ENV_TYPE.WEAPP:
         case Taro.ENV_TYPE.ALIPAY:
         case Taro.ENV_TYPE.SWAN: {
           const index = Math.max(idx - 1, 0)
-          this.setState({
-            _scrollIntoView: `tab${this._tabId}${index}`
-          })
+          setScrollState(prev => ({
+            ...prev,
+            _scrollIntoView: `tab${tabIdRef.current}${index}`
+          }))
           break
         }
         case Taro.ENV_TYPE.WEB: {
           const index = Math.max(idx - 1, 0)
-          const prevTabItem = this.tabHeaderRef.children[index]
+          const prevTabItem = tabHeaderRef.current?.children[index]
           prevTabItem &&
-            this.setState({
+            setScrollState(prev => ({
+              ...prev,
               _scrollTop: prevTabItem.offsetTop,
               _scrollLeft: prevTabItem.offsetLeft
-            })
+            }))
           break
         }
         default: {
@@ -71,188 +75,158 @@ export default class AtTabs extends React.Component<AtTabsProps, AtTabsState> {
     }
   }
 
-  private handleClick(index: number, event: CommonEvent): void {
-    this.props.onClick(index, event)
+  const handleClick = (index: number, event: CommonEvent): void => {
+    onClick && onClick(index, event)
   }
 
-  private handleTouchStart(e: ITouchEvent): void {
-    const { swipeable, tabDirection } = this.props
+  const handleTouchStart = (e: ITouchEvent): void => {
     if (!swipeable || tabDirection === 'vertical') return
-    // 获取触摸时的原点
-    this._touchDot = e.touches[0].pageX
-    // 使用js计时器记录时间
-    this._timer = setInterval(() => {
-      this._interval++
+    touchDotRef.current = e.touches[0].pageX
+    timerRef.current = setInterval(() => {
+      intervalRef.current++
     }, 100)
   }
 
-  private handleTouchMove(e: ITouchEvent): void {
-    const { swipeable, tabDirection, current, tabList } = this.props
+  const handleTouchMove = (e: ITouchEvent): void => {
     if (!swipeable || tabDirection === 'vertical') return
 
     const touchMove = e.touches[0].pageX
-    const moveDistance = touchMove - this._touchDot
+    const moveDistance = touchMove - touchDotRef.current
     const maxIndex = tabList.length
 
     if (
-      !this._isMoving &&
-      this._interval < MAX_INTERVAL &&
-      this._touchDot > 20
+      !isMovingRef.current &&
+      intervalRef.current < MAX_INTERVAL &&
+      touchDotRef.current > 20
     ) {
-      // 向左滑动
       if (current + 1 < maxIndex && moveDistance <= -MIN_DISTANCE) {
-        this._isMoving = true
-        this.handleClick(current + 1, e)
-
-        // 向右滑动
+        isMovingRef.current = true
+        handleClick(current + 1, e)
       } else if (current - 1 >= 0 && moveDistance >= MIN_DISTANCE) {
-        this._isMoving = true
-        this.handleClick(current - 1, e)
+        isMovingRef.current = true
+        handleClick(current - 1, e)
       }
     }
   }
 
-  private handleTouchEnd(): void {
-    const { swipeable, tabDirection } = this.props
+  const handleTouchEnd = (): void => {
     if (!swipeable || tabDirection === 'vertical') return
 
-    this._timer && clearInterval(this._timer)
-    this._interval = 0
-    this._isMoving = false
+    timerRef.current && clearInterval(timerRef.current)
+    intervalRef.current = 0
+    isMovingRef.current = false
   }
 
-  private getTabHeaderRef(): void {
-    if (ENV === Taro.ENV_TYPE.WEB) {
-      this.tabHeaderRef = document.getElementById(this._tabId)
+  useEffect(() => {
+    getTabHeaderRef()
+    updateState(current)
+    return () => {
+      tabHeaderRef.current = null
     }
+    // componentDidMount / componentWillUnmount
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const prevScrollRef = useRef(scroll)
+  const prevCurrentRef = useRef(current)
+  const isMountRef = useRef(true)
+  useEffect(() => {
+    if (isMountRef.current) {
+      isMountRef.current = false
+      return
+    }
+    if (scroll !== prevScrollRef.current) {
+      getTabHeaderRef()
+      prevScrollRef.current = scroll
+    }
+    if (current !== prevCurrentRef.current) {
+      updateState(current)
+      prevCurrentRef.current = current
+    }
+  }, [scroll, current])
+
+  const { _scrollLeft, _scrollTop, _scrollIntoView } = scrollState
+
+  const heightStyle = { height }
+  const underlineStyle = {
+    height: tabDirection === 'vertical' ? `${tabList.length * 100}%` : '1PX',
+    width: tabDirection === 'horizontal' ? `${tabList.length * 100}%` : '1PX'
+  }
+  const bodyStyle: React.CSSProperties = {}
+  let transformStyle = `translate3d(0px, -${current * 100}%, 0px)`
+  if (tabDirection === 'horizontal') {
+    transformStyle = `translate3d(-${current * 100}%, 0px, 0px)`
+  }
+  Object.assign(bodyStyle, {
+    transform: transformStyle
+  })
+  if (!animated) {
+    bodyStyle.transition = 'unset'
   }
 
-  public UNSAFE_componentWillReceiveProps(nextProps: AtTabsProps): void {
-    if (nextProps.scroll !== this.props.scroll) {
-      this.getTabHeaderRef()
-    }
-    if (nextProps.current !== this.props.current) {
-      this.updateState(nextProps.current)
-    }
-  }
-
-  public componentDidMount(): void {
-    this.getTabHeaderRef()
-    this.updateState(this.props.current)
-  }
-
-  public componentWillUnmount(): void {
-    this.tabHeaderRef = null
-  }
-
-  public render(): JSX.Element {
-    const {
-      customStyle = '',
-      className,
-      height,
-      tabDirection,
-      animated,
-      tabList,
-      scroll,
-      current
-    } = this.props
-    const { _scrollLeft, _scrollTop, _scrollIntoView } = this.state
-
-    const heightStyle = { height }
-    const underlineStyle = {
-      height: tabDirection === 'vertical' ? `${tabList.length * 100}%` : '1PX',
-      width: tabDirection === 'horizontal' ? `${tabList.length * 100}%` : '1PX'
-    }
-    const bodyStyle: React.CSSProperties = {}
-    let transformStyle = `translate3d(0px, -${current * 100}%, 0px)`
-    if (tabDirection === 'horizontal') {
-      transformStyle = `translate3d(-${current * 100}%, 0px, 0px)`
-    }
-    Object.assign(bodyStyle, {
-      transform: transformStyle
+  const tabItems = tabList.map((item, idx) => {
+    const itemCls = classNames({
+      'at-tabs__item': true,
+      'at-tabs__item--active': current === idx
     })
-    if (!animated) {
-      bodyStyle.transition = 'unset'
-    }
-
-    const tabItems = tabList.map((item, idx) => {
-      const itemCls = classNames({
-        'at-tabs__item': true,
-        'at-tabs__item--active': current === idx
-      })
-
-      return (
-        <View
-          className={itemCls}
-          id={`tab${this._tabId}${idx}`}
-          key={`at-tabs-item-${idx}`}
-          onClick={this.handleClick.bind(this, idx)}
-        >
-          {item.title}
-          <View className='at-tabs__item-underline'></View>
-        </View>
-      )
-    })
-    const rootCls = classNames(
-      {
-        'at-tabs': true,
-        'at-tabs--scroll': scroll,
-        [`at-tabs--${tabDirection}`]: true,
-        [`at-tabs--${ENV}`]: true
-      },
-      className
-    )
-    const scrollX = tabDirection === 'horizontal'
-    const scrollY = tabDirection === 'vertical'
 
     return (
-      <View className={rootCls} style={mergeStyle(heightStyle, customStyle)}>
-        {scroll ? (
-          <ScrollView
-            id={this._tabId}
-            className='at-tabs__header'
-            style={heightStyle}
-            scrollX={scrollX}
-            scrollY={scrollY}
-            scrollWithAnimation
-            scrollLeft={_scrollLeft}
-            scrollTop={_scrollTop}
-            scrollIntoView={_scrollIntoView}
-          >
-            {tabItems}
-          </ScrollView>
-        ) : (
-          <View id={this._tabId} className='at-tabs__header'>
-            {tabItems}
-          </View>
-        )}
-        <View
-          className='at-tabs__body'
-          onTouchStart={this.handleTouchStart.bind(this)}
-          onTouchEnd={this.handleTouchEnd.bind(this)}
-          onTouchMove={this.handleTouchMove.bind(this)}
-          style={mergeStyle(bodyStyle, heightStyle)}
-        >
-          <View className='at-tabs__underline' style={underlineStyle}></View>
-          {this.props.children}
-        </View>
+      <View
+        className={itemCls}
+        id={`tab${tabIdRef.current}${idx}`}
+        key={`at-tabs-item-${idx}`}
+        onClick={(event: CommonEvent) => handleClick(idx, event)}
+      >
+        {item.title}
+        <View className='at-tabs__item-underline'></View>
       </View>
     )
-  }
-}
+  })
+  const rootCls = classNames(
+    {
+      'at-tabs': true,
+      'at-tabs--scroll': scroll,
+      [`at-tabs--${tabDirection}`]: true,
+      [`at-tabs--${ENV}`]: true
+    },
+    className
+  )
+  const scrollX = tabDirection === 'horizontal'
+  const scrollY = tabDirection === 'vertical'
 
-AtTabs.defaultProps = {
-  customStyle: '',
-  className: '',
-  tabDirection: 'horizontal',
-  height: '',
-  current: 0,
-  swipeable: true,
-  scroll: false,
-  animated: true,
-  tabList: [],
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  onClick: (): void => {}
+  return (
+    <View className={rootCls} style={mergeStyle(heightStyle, customStyle)}>
+      {scroll ? (
+        <ScrollView
+          id={tabIdRef.current}
+          className='at-tabs__header'
+          style={heightStyle}
+          scrollX={scrollX}
+          scrollY={scrollY}
+          scrollWithAnimation
+          scrollLeft={_scrollLeft}
+          scrollTop={_scrollTop}
+          scrollIntoView={_scrollIntoView}
+        >
+          {tabItems}
+        </ScrollView>
+      ) : (
+        <View id={tabIdRef.current} className='at-tabs__header'>
+          {tabItems}
+        </View>
+      )}
+      <View
+        className='at-tabs__body'
+        onTouchStart={handleTouchStart}
+        onTouchEnd={handleTouchEnd}
+        onTouchMove={handleTouchMove}
+        style={mergeStyle(bodyStyle, heightStyle)}
+      >
+        <View className='at-tabs__underline' style={underlineStyle}></View>
+        {children}
+      </View>
+    </View>
+  )
 }
 
 AtTabs.propTypes = {
@@ -267,3 +241,5 @@ AtTabs.propTypes = {
   tabList: PropTypes.array,
   onClick: PropTypes.func
 }
+
+export default AtTabs

--- a/packages/taro-ui/src/components/tag/index.tsx
+++ b/packages/taro-ui/src/components/tag/index.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames'
-import PropTypes, { InferProps } from 'prop-types'
+import PropTypes from 'prop-types'
 import React from 'react'
 import { View } from '@tarojs/components'
 import { CommonEvent } from '@tarojs/components/types/common'
@@ -14,12 +14,19 @@ const TYPE_CLASS = {
   primary: 'primary'
 }
 
-export default class AtTag extends React.Component<AtTagProps> {
-  public static defaultProps: AtTagProps
-  public static propTypes: InferProps<AtTagProps>
-
-  private onClick(event: CommonEvent): void {
-    const { name = '', active = false, disabled, onClick } = this.props
+export default function AtTag({
+  size = 'normal',
+  type = '',
+  name = '',
+  circle = false,
+  disabled = false,
+  active = false,
+  customStyle = {},
+  className,
+  children,
+  onClick
+}: AtTagProps): JSX.Element {
+  const handleClick = (event: CommonEvent): void => {
     if (!disabled) {
       typeof onClick === 'function' &&
         onClick(
@@ -32,45 +39,25 @@ export default class AtTag extends React.Component<AtTagProps> {
     }
   }
 
-  public render(): JSX.Element {
-    const {
-      size = 'normal',
-      type = '',
-      circle = false,
-      disabled = false,
-      active = false,
-      customStyle
-    } = this.props
-    const rootClassName = ['at-tag']
+  const rootClassName = ['at-tag']
 
-    const classObject = {
-      [`at-tag--${SIZE_CLASS[size]}`]: SIZE_CLASS[size],
-      [`at-tag--${type}`]: TYPE_CLASS[type],
-      'at-tag--disabled': disabled,
-      'at-tag--active': active,
-      'at-tag--circle': circle
-    }
-
-    return (
-      <View
-        className={classNames(rootClassName, classObject, this.props.className)}
-        style={customStyle}
-        onClick={this.onClick.bind(this)}
-      >
-        {this.props.children}
-      </View>
-    )
+  const classObject = {
+    [`at-tag--${SIZE_CLASS[size]}`]: SIZE_CLASS[size],
+    [`at-tag--${type}`]: TYPE_CLASS[type],
+    'at-tag--disabled': disabled,
+    'at-tag--active': active,
+    'at-tag--circle': circle
   }
-}
 
-AtTag.defaultProps = {
-  size: 'normal',
-  type: '',
-  name: '',
-  circle: false,
-  active: false,
-  disabled: false,
-  customStyle: {}
+  return (
+    <View
+      className={classNames(rootClassName, classObject, className)}
+      style={customStyle}
+      onClick={handleClick}
+    >
+      {children}
+    </View>
+  )
 }
 
 AtTag.propTypes = {

--- a/packages/taro-ui/src/components/textarea/index.tsx
+++ b/packages/taro-ui/src/components/textarea/index.tsx
@@ -1,11 +1,11 @@
 import classNames from 'classnames'
-import PropTypes, { InferProps } from 'prop-types'
+import PropTypes from 'prop-types'
 import React from 'react'
 import { Textarea, View } from '@tarojs/components'
 import { CommonEvent } from '@tarojs/components/types/common'
 import Taro from '@tarojs/taro'
 import { AtTextareaProps } from '../../../types/textarea'
-import { pxTransform } from '../../common/utils'
+import { noop, pxTransform } from '../../common/utils'
 
 type ExtendEvent = {
   target: {
@@ -23,119 +23,97 @@ function getMaxLength(
   return maxLength
 }
 
-const ENV = Taro.getEnv()
+function AtTextarea({
+  customStyle = '',
+  className = '',
+  cursorSpacing = 100,
+  maxLength = 200,
+  placeholder = '',
+  disabled = false,
+  autoFocus = false,
+  focus = false,
+  showConfirmBar = false,
+  selectionStart = -1,
+  selectionEnd = -1,
+  count = true,
+  fixed = false,
+  height = '',
+  textOverflowForbidden = true,
+  value,
+  placeholderStyle,
+  placeholderClass,
+  onChange = noop,
+  onFocus,
+  onBlur,
+  onConfirm,
+  onLinechange
+}: AtTextareaProps): JSX.Element {
+  const ENV = Taro.getEnv()
 
-export default class AtTextarea extends React.Component<AtTextareaProps> {
-  public static defaultProps: AtTextareaProps
-  public static propTypes: InferProps<AtTextareaProps>
-
-  private handleInput = (event: CommonEvent & ExtendEvent): void => {
-    this.props.onChange(event.detail.value, event)
+  const handleInput = (event: CommonEvent & ExtendEvent): void => {
+    onChange(event.detail.value, event)
   }
 
-  private handleFocus = (event: CommonEvent): void => {
-    this.props.onFocus && this.props.onFocus(event)
+  const handleFocus = (event: CommonEvent): void => {
+    onFocus && onFocus(event)
   }
 
-  private handleBlur = (event: CommonEvent): void => {
-    this.props.onBlur && this.props.onBlur(event)
+  const handleBlur = (event: CommonEvent): void => {
+    onBlur && onBlur(event)
   }
 
-  private handleConfirm = (event: CommonEvent): void => {
-    this.props.onConfirm && this.props.onConfirm(event)
+  const handleConfirm = (event: CommonEvent): void => {
+    onConfirm && onConfirm(event)
   }
 
-  private handleLinechange = (event: CommonEvent): void => {
-    this.props.onLinechange && this.props.onLinechange(event)
+  const handleLinechange = (event: CommonEvent): void => {
+    onLinechange && onLinechange(event)
   }
 
-  public render(): JSX.Element {
-    const {
-      customStyle,
-      className,
-      value,
-      cursorSpacing,
-      placeholder,
-      placeholderStyle,
-      placeholderClass,
-      maxLength = 200,
-      count,
-      disabled,
-      autoFocus,
-      focus,
-      showConfirmBar,
-      selectionStart,
-      selectionEnd,
-      fixed,
-      textOverflowForbidden = true,
-      height
-    } = this.props
+  const _maxLength = parseInt(maxLength.toString())
+  const actualMaxLength = getMaxLength(_maxLength, textOverflowForbidden)
+  const textareaStyle = height ? `height:${pxTransform(Number(height))}` : ''
+  const rootCls = classNames(
+    'at-textarea',
+    `at-textarea--${ENV}`,
+    {
+      'at-textarea--error': _maxLength < (value || '').length
+    },
+    className
+  )
+  const placeholderCls = classNames('placeholder', placeholderClass)
 
-    const _maxLength = parseInt(maxLength.toString())
-    const actualMaxLength = getMaxLength(_maxLength, textOverflowForbidden)
-    const textareaStyle = height ? `height:${pxTransform(Number(height))}` : ''
-    const rootCls = classNames(
-      'at-textarea',
-      `at-textarea--${ENV}`,
-      {
-        'at-textarea--error': _maxLength < (value || '').length
-      },
-      className
-    )
-    const placeholderCls = classNames('placeholder', placeholderClass)
-
-    return (
-      <View className={rootCls} style={customStyle}>
-        <Textarea
-          className='at-textarea__textarea'
-          style={textareaStyle}
-          placeholderStyle={placeholderStyle}
-          placeholderClass={placeholderCls}
-          cursorSpacing={cursorSpacing}
-          value={value || ''}
-          maxlength={actualMaxLength}
-          placeholder={placeholder}
-          disabled={disabled}
-          autoFocus={autoFocus}
-          focus={focus}
-          showConfirmBar={showConfirmBar}
-          selectionStart={selectionStart}
-          selectionEnd={selectionEnd}
-          fixed={fixed}
-          onInput={this.handleInput}
-          onFocus={this.handleFocus}
-          onBlur={this.handleBlur}
-          onConfirm={this.handleConfirm}
-          onLineChange={this.handleLinechange}
-        />
-        {count && (
-          <View className='at-textarea__counter'>
-            {(value || '').length}/{_maxLength}
-          </View>
-        )}
-      </View>
-    )
-  }
-}
-
-AtTextarea.defaultProps = {
-  customStyle: '',
-  className: '',
-  cursorSpacing: 100,
-  maxLength: 200,
-  placeholder: '',
-  disabled: false,
-  autoFocus: false,
-  focus: false,
-  showConfirmBar: false,
-  selectionStart: -1,
-  selectionEnd: -1,
-  count: true,
-  fixed: false,
-  height: '',
-  textOverflowForbidden: true,
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  onChange: (): void => {}
+  return (
+    <View className={rootCls} style={customStyle}>
+      <Textarea
+        className='at-textarea__textarea'
+        style={textareaStyle}
+        placeholderStyle={placeholderStyle}
+        placeholderClass={placeholderCls}
+        cursorSpacing={cursorSpacing}
+        value={value || ''}
+        maxlength={actualMaxLength}
+        placeholder={placeholder}
+        disabled={disabled}
+        autoFocus={autoFocus}
+        focus={focus}
+        showConfirmBar={showConfirmBar}
+        selectionStart={selectionStart}
+        selectionEnd={selectionEnd}
+        fixed={fixed}
+        onInput={handleInput}
+        onFocus={handleFocus}
+        onBlur={handleBlur}
+        onConfirm={handleConfirm}
+        onLineChange={handleLinechange}
+      />
+      {count && (
+        <View className='at-textarea__counter'>
+          {(value || '').length}/{_maxLength}
+        </View>
+      )}
+    </View>
+  )
 }
 
 AtTextarea.propTypes = {
@@ -163,3 +141,5 @@ AtTextarea.propTypes = {
   onBlur: PropTypes.func,
   onConfirm: PropTypes.func
 }
+
+export default AtTextarea

--- a/packages/taro-ui/src/components/timeline/index.tsx
+++ b/packages/taro-ui/src/components/timeline/index.tsx
@@ -1,88 +1,77 @@
 import classNames from 'classnames'
-import PropTypes, { InferProps } from 'prop-types'
+import PropTypes from 'prop-types'
 import React from 'react'
 import { Text, View } from '@tarojs/components'
 import { AtTimelineProps } from '../../../types/timeline'
 
-export default class AtTimeline extends React.Component<AtTimelineProps> {
-  public static defaultProps: AtTimelineProps
-  public static propTypes: InferProps<AtTimelineProps>
+export default function AtTimeline({
+  pending = false,
+  items = [],
+  customStyle = {},
+  className,
+  onClickItem
+}: AtTimelineProps): JSX.Element {
+  const rootClassName = ['at-timeline']
+  if (pending) rootClassName.push('at-timeline--pending')
 
-  public render(): JSX.Element {
-    const { pending, items, customStyle, onClickItem } = this.props
+  const rootClassObject = {
+    'at-timeline--pending': pending
+  }
 
-    const rootClassName = ['at-timeline']
-    if (pending) rootClassName.push('at-timeline--pending')
+  const itemElems = items.map((item, index) => {
+    const { title = '', color, icon, content = [] } = item
 
-    const rootClassObject = {
-      'at-timeline--pending': pending
+    const iconClass = classNames({
+      'at-icon': true,
+      [`at-icon-${icon}`]: icon
+    })
+
+    const itemRootClassName = ['at-timeline-item']
+    if (color) itemRootClassName.push(`at-timeline-item--${color}`)
+
+    const dotClass: string[] = []
+    if (icon) {
+      dotClass.push('at-timeline-item__icon')
+    } else {
+      dotClass.push('at-timeline-item__dot')
     }
 
-    const itemElems = items.map((item, index) => {
-      const { title = '', color, icon, content = [] } = item
+    const handleItemClick = (itemIndex: number, e: any): void => {
+      onClickItem?.(itemIndex, e)
+    }
 
-      const iconClass = classNames({
-        'at-icon': true,
-        [`at-icon-${icon}`]: icon
-      })
-
-      const itemRootClassName = ['at-timeline-item']
-      if (color) itemRootClassName.push(`at-timeline-item--${color}`)
-
-      const dotClass: string[] = []
-      if (icon) {
-        dotClass.push('at-timeline-item__icon')
-      } else {
-        dotClass.push('at-timeline-item__dot')
-      }
-
-      const handleItemClick = (index, e) => {
-        onClickItem?.(index, e)
-      }
-
-      return (
-        <View
-          className={classNames(itemRootClassName)}
-          key={`at-timeline-item-${index}`}
-          onClick={e => handleItemClick(index, e)}
-        >
-          <View className='at-timeline-item__tail'></View>
-          <View className={classNames(dotClass)}>
-            {icon && <Text className={iconClass}></Text>}
-          </View>
-          <View className='at-timeline-item__content'>
-            <View className='at-timeline-item__content-item'>{title}</View>
-            {content.map((sub, subIndex) => (
-              <View
-                className='at-timeline-item__content-item at-timeline-item__content--sub'
-                key={subIndex}
-              >
-                {sub}
-              </View>
-            ))}
-          </View>
-        </View>
-      )
-    })
     return (
       <View
-        className={classNames(
-          rootClassName,
-          rootClassObject,
-          this.props.className
-        )}
-        style={customStyle}
+        className={classNames(itemRootClassName)}
+        key={`at-timeline-item-${index}`}
+        onClick={e => handleItemClick(index, e)}
       >
-        {itemElems}
+        <View className='at-timeline-item__tail'></View>
+        <View className={classNames(dotClass)}>
+          {icon && <Text className={iconClass}></Text>}
+        </View>
+        <View className='at-timeline-item__content'>
+          <View className='at-timeline-item__content-item'>{title}</View>
+          {content.map((sub, subIndex) => (
+            <View
+              className='at-timeline-item__content-item at-timeline-item__content--sub'
+              key={subIndex}
+            >
+              {sub}
+            </View>
+          ))}
+        </View>
       </View>
     )
-  }
-}
-
-AtTimeline.defaultProps = {
-  pending: false,
-  items: [],
-  customStyle: {}
+  })
+  return (
+    <View
+      className={classNames(rootClassName, rootClassObject, className)}
+      style={customStyle}
+    >
+      {itemElems}
+    </View>
+  )
 }
 
 AtTimeline.propTypes = {

--- a/packages/taro-ui/src/components/toast/index.tsx
+++ b/packages/taro-ui/src/components/toast/index.tsx
@@ -1,154 +1,143 @@
 import classNames from 'classnames'
-import PropTypes, { InferProps } from 'prop-types'
-import React from 'react'
+import PropTypes from 'prop-types'
+import React, { useEffect, useRef, useState } from 'react'
 import { Image, Text, View } from '@tarojs/components'
 import { CommonEvent } from '@tarojs/components/types/common'
-import { AtToastProps, AtToastState } from '../../../types/toast'
+import { AtToastProps } from '../../../types/toast'
 import statusImg from './img.json'
 
-export default class AtToast extends React.Component<
-  AtToastProps,
-  AtToastState
-> {
-  public static defaultProps: AtToastProps
-  public static propTypes: InferProps<AtToastProps>
+function AtToast({
+  duration = 3000,
+  isOpened = false,
+  customStyle,
+  text,
+  icon,
+  status,
+  image,
+  hasMask,
+  className,
+  onClick,
+  onClose
+}: AtToastProps): JSX.Element | null {
+  const [_isOpened, setIsOpened] = useState(isOpened)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const isOpenedRef = useRef(_isOpened)
+  isOpenedRef.current = _isOpened
 
-  private _timer: ReturnType<typeof setTimeout> | null
-
-  public constructor(props: AtToastProps) {
-    super(props)
-    const { isOpened, duration } = props
-    if (isOpened) {
-      this.makeTimer(duration || 0)
-    }
-    this._timer = null
-    this.state = {
-      _isOpened: isOpened
-    }
-  }
-
-  private clearTimmer(): void {
-    if (this._timer) {
-      clearTimeout(this._timer)
-      this._timer = null
+  const clearTimmer = (): void => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current)
+      timerRef.current = null
     }
   }
 
-  private makeTimer(duration: number): void {
-    if (duration === 0) {
+  const handleClose = (event?: CommonEvent): void => {
+    if (typeof onClose === 'function') {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      onClose(event!)
+    }
+  }
+
+  const close = (): void => {
+    if (isOpenedRef.current) {
+      setIsOpened(false)
+      handleClose()
+      clearTimmer()
+    }
+  }
+
+  const makeTimer = (timerDuration: number): void => {
+    if (timerDuration === 0) {
       return
     }
-    this._timer = setTimeout(() => {
-      this.close()
-    }, +duration)
+    timerRef.current = setTimeout(() => {
+      close()
+    }, +timerDuration)
   }
 
-  private close(): void {
-    const { _isOpened } = this.state
-    if (_isOpened) {
-      this.setState(
-        {
-          _isOpened: false
-        },
-        this.handleClose // TODO: Fix dirty hack
-      )
-      this.clearTimmer()
+  useEffect(() => {
+    if (isOpened) {
+      makeTimer(duration || 0)
+      timerRef.current = null
     }
-  }
+    // constructor: timer started then ref cleared
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
-  private handleClose(event?: CommonEvent): void {
-    // TODO: Fix dirty hack
-    if (typeof this.props.onClose === 'function') {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      this.props.onClose(event!)
+  const isMountRef = useRef(true)
+  useEffect(() => {
+    if (isMountRef.current) {
+      isMountRef.current = false
+      return
     }
-  }
 
-  private handleClick = (event: CommonEvent): void => {
-    const { onClick, status } = this.props
+    if (!isOpened) {
+      close()
+      return
+    }
+
+    if (!isOpenedRef.current) {
+      setIsOpened(true)
+    } else {
+      clearTimmer()
+    }
+    makeTimer(duration || 0)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpened, duration])
+
+  const handleClick = (event: CommonEvent): void => {
     if (status === 'loading') {
       return
     }
     if (onClick) {
       return onClick(event)
     }
-    this.close()
+    close()
   }
 
-  public UNSAFE_componentWillReceiveProps(nextProps: AtToastProps): void {
-    const { isOpened, duration } = nextProps
-    if (!isOpened) {
-      this.close()
-      return
-    }
+  /* eslint-disable @typescript-eslint/no-non-null-assertion */
+  const realImg = image || statusImg[status!] || null
+  const isRenderIcon = !!(icon && !(image || statusImg[status!]))
+  /* eslint-enable @typescript-eslint/no-non-null-assertion */
 
-    if (!this.state._isOpened) {
-      this.setState({
-        _isOpened: true
-      })
-    } else {
-      this.clearTimmer()
-    }
-    this.makeTimer(duration || 0)
-  }
+  const bodyClass = classNames('toast-body', {
+    'at-toast__body--custom-image': image,
+    'toast-body--text': !realImg && !icon,
+    [`at-toast__body--${status}`]: !!status
+  })
 
-  public render(): JSX.Element | null {
-    const { _isOpened } = this.state
-    const { customStyle, text, icon, status, image, hasMask } = this.props
+  const iconClass = classNames('at-icon', {
+    [`at-icon-${icon}`]: icon
+  })
 
-    /* eslint-disable @typescript-eslint/no-non-null-assertion */
-    const realImg = image || statusImg[status!] || null
-    const isRenderIcon = !!(icon && !(image || statusImg[status!]))
-    /* eslint-enable @typescript-eslint/no-non-null-assertion */
-
-    const bodyClass = classNames('toast-body', {
-      'at-toast__body--custom-image': image,
-      'toast-body--text': !realImg && !icon,
-      [`at-toast__body--${status}`]: !!status
-    })
-
-    const iconClass = classNames('at-icon', {
-      [`at-icon-${icon}`]: icon
-    })
-
-    return _isOpened ? (
-      <View className={classNames('at-toast', this.props.className)}>
-        {hasMask && <View className='at-toast__overlay' />}
-        <View
-          className={bodyClass}
-          style={customStyle}
-          onClick={this.handleClick}
-        >
-          <View className='toast-body-content'>
-            {realImg ? (
-              <View className='toast-body-content__img'>
-                <Image
-                  className='toast-body-content__img-item'
-                  src={realImg}
-                  mode='scaleToFill'
-                />
-              </View>
-            ) : null}
-            {isRenderIcon && (
-              <View className='toast-body-content__icon'>
-                <Text className={iconClass} />
-              </View>
-            )}
-            {text && (
-              <View className='toast-body-content__info'>
-                <Text>{text}</Text>
-              </View>
-            )}
-          </View>
+  return _isOpened ? (
+    <View className={classNames('at-toast', className)}>
+      {hasMask && <View className='at-toast__overlay' />}
+      <View className={bodyClass} style={customStyle} onClick={handleClick}>
+        <View className='toast-body-content'>
+          {realImg ? (
+            <View className='toast-body-content__img'>
+              <Image
+                className='toast-body-content__img-item'
+                src={realImg}
+                mode='scaleToFill'
+              />
+            </View>
+          ) : null}
+          {isRenderIcon && (
+            <View className='toast-body-content__icon'>
+              <Text className={iconClass} />
+            </View>
+          )}
+          {text && (
+            <View className='toast-body-content__info'>
+              <Text>{text}</Text>
+            </View>
+          )}
         </View>
       </View>
-    ) : null
-  }
-}
-
-AtToast.defaultProps = {
-  duration: 3000,
-  isOpened: false
+    </View>
+  ) : null
 }
 
 AtToast.propTypes = {
@@ -162,3 +151,5 @@ AtToast.propTypes = {
   onClick: PropTypes.func,
   onClose: PropTypes.func
 }
+
+export default AtToast

--- a/packages/taro-ui/test/__mock__/taro.js
+++ b/packages/taro-ui/test/__mock__/taro.js
@@ -56,6 +56,8 @@ const taro = {
     once: jest.fn(),
     trigger: jest.fn()
   },
+  useDidShow: jest.fn(),
+  useDidHide: jest.fn(),
   chooseImage: jest.fn(),
   showToast: jest.fn(),
   hideToast: jest.fn(),


### PR DESCRIPTION
## Summary

本 PR 将 `packages/taro-ui/src/components` 下全部组件（含子组件，共 58 个入口）由 Class 组件迁移为 Function 组件，并补充迁移指南与若干行为修复。

> **说明：** 分支名 `feat/loading-to-fc` 为历史命名；`AtLoading` 仅为其中一项，并非本 PR 唯一范围。

### 主要变更

- 批量改写：`accordion`、`toast`、`modal`、`swipe-action`、`calendar` 子树等（见 Files changed）
- 新增 `docs/MIGRATION_FC.md`：迁移约定、分阶段记录、常见模式（`useRef` / `useLayoutEffect` / `forwardRef` 等）
- 行为修复（相对纯机械迁移）：
  - `load-more` / `form`：事件参数不再误用箭头函数中的 `arguments`
  - `accordion`：展开/收起动画按切换前 `open` 计算高度
  - `swipe-action`：关闭时分步 `setOffsetSize`，保留关闭动画

### 非目标

- 不改变对外 props / DOM 结构 / 样式 class 的约定（见迁移文档）
- `src/common/component.tsx` 中 `AtComponent` 基类仍保留

## Test plan

- [x] `pnpm run build:ui`
- [x] `cd packages/taro-ui && pnpm test`（文档记录：354 项测试 / 314 快照）
- [x] 手动抽查：`accordion` 展开收起、`swipe-action` 滑动关闭、`toast`/`modal` 显隐

## Rollback

如需回滚，本 PR 为单一大 diff；若需更小粒度回滚，见下方「拆分方案」。