### PR TITLE
refactor(ci): 用 job 级条件限制 publish 仅对 release 提交执行

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,10 +17,12 @@ env:
 permissions: {}
 jobs:
   publish:
-    # push 仅 release 提交才执行；非 next 分支还需含 --tag= 参数
-    if: 
-      startsWith( env.COMMIT_MESSAGE , 'chore(release):' ) == true ||
-      (github.event_name == 'push' && github.ref_name != 'next' && contains( env.COMMIT_MESSAGE , '--tag=' ) == true)
+    # 仅 release 提交（chore(release):）触发；pull_request 须已 merge
+    # push 到非 next 分支时，commit message 还需包含 --tag=
+    if: |
+      (github.event_name != 'pull_request' || github.event.pull_request.merged == true) &&
+      startsWith(env.COMMIT_MESSAGE, 'chore(release):') &&
+      (github.event_name != 'push' || github.ref_name == 'next' || contains(env.COMMIT_MESSAGE, '--tag='))
     permissions:
       contents: write # to create tags and refs
       issues: write # to create comment

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,6 +24,7 @@ jobs:
       !(github.event_name == 'push' && github.ref_name != 'next' && contains( env.COMMIT_MESSAGE , '--tag=' ) != true)
     permissions:
       contents: write # to create tags and refs
+      actions: write # to cancel running workflow (andymckay/cancel-action)
       issues: write # to create comment
       pull-requests: write # to create comment and so on
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,9 @@ permissions: {}
 jobs:
   publish:
     # push 仅 release 提交才执行；非 next 分支还需含 --tag= 参数
-    if: startsWith( env.COMMIT_MESSAGE , 'chore(release):' ) == true
+    if: 
+      startsWith( env.COMMIT_MESSAGE , 'chore(release):' ) == true ||
+      (github.event_name == 'push' && github.ref_name != 'next' && contains( env.COMMIT_MESSAGE , '--tag=' ) == true)
     permissions:
       contents: write # to create tags and refs
       issues: write # to create comment

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,9 +17,10 @@ env:
 permissions: {}
 jobs:
   publish:
+    # push 仅 release 提交才执行；非 next 分支还需含 --tag= 参数
+    if: startsWith( env.COMMIT_MESSAGE , 'chore(release):' ) == true
     permissions:
       contents: write # to create tags and refs
-      actions: write # to cancel running workflow (andymckay/cancel-action)
       issues: write # to create comment
       pull-requests: write # to create comment and so on
 
@@ -55,14 +56,6 @@ jobs:
           echo "COMMIT_MESSAGE=${COMMIT_MESSAGE}" >> $GITHUB_ENV
       - name: Show commit message
         run: echo "$COMMIT_MESSAGE"
-
-      - name: Commit message compliance verification
-        if: startsWith( env.COMMIT_MESSAGE , 'chore(release):' ) != true
-        uses: andymckay/cancel-action@0.3
-
-      - name: Publish push tag verification
-        if: github.event_name == 'push' && github.ref_name != 'next' && contains( env.COMMIT_MESSAGE , '--tag=' ) != true
-        uses: andymckay/cancel-action@0.3
 
       # Get & check npm publish
       - name: Get publish params

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,9 +20,8 @@ jobs:
     # 仅 release 提交（chore(release):）触发；pull_request 须已 merge
     # push 到非 next 分支时，commit message 还需包含 --tag=
     if: |
-      (github.event_name != 'pull_request' || github.event.pull_request.merged == true) &&
-      startsWith(env.COMMIT_MESSAGE, 'chore(release):') &&
-      (github.event_name != 'push' || github.ref_name == 'next' || contains(env.COMMIT_MESSAGE, '--tag='))
+      startsWith( env.COMMIT_MESSAGE , 'chore(release):' ) ||
+      !(github.event_name == 'push' && github.ref_name != 'next' && contains( env.COMMIT_MESSAGE , '--tag=' ) != true)
     permissions:
       contents: write # to create tags and refs
       issues: write # to create comment


### PR DESCRIPTION
## 概述

简化 `publish` workflow：用 job 级 `if` 替代运行中的 `cancel-action` 步骤。

## 动机

原先 workflow 通过 `andymckay/cancel-action` 在以下情况中止运行：
1. commit message 不以 `chore(release):` 开头
2. 非 `next` 分支的 push 且 commit message 中不含 `--tag=`

这种方式需要：
- `actions: write` 权限
- 先执行 checkout、setup 等步骤，校验才能生效
- 依赖第三方 action 中途取消 workflow

将主要门禁前移到 job 级 `if`，可去掉上述依赖，意图也更直观。