### PR TITLE
fix(style): restore Taro PX units mistakenly lowercased by Prettier

### DIFF
--- a/packages/taro-ui/rn/components/countdown/index.scss
+++ b/packages/taro-ui/rn/components/countdown/index.scss
@@ -48,7 +48,7 @@ $font-size: $font-size-lg;
   &--card {
     .at-count-down__time-box {
       padding: $spacing-v-xs 0;
-      border: 1px solid $color-border-grey;
+      border: 1PX solid $color-border-grey;
       border-radius: $border-radius-md;
       color: #ff4949;
       //  display: inline-block;
@@ -64,7 +64,7 @@ $font-size: $font-size-lg;
         position: absolute;
         content: '';
         width: 100%;
-        height: 1px;
+        height: 1PX;
         top: 50%;
         left: 0;
         z-index: $zindex-divider;

--- a/packages/taro-ui/rn/style/components/badge.scss
+++ b/packages/taro-ui/rn/style/components/badge.scss
@@ -39,7 +39,7 @@ $at-badge-box-shadow: 0 4px 8px 0
   &__num {
     position: absolute;
     top: -$at-badge-border-radius;
-    right: -16px;
+    right: -16PX;
     padding: 0 $spacing-h-sm;
     color: $at-badge-color;
     font-size: $at-badge-font-size;

--- a/packages/taro-ui/rn/style/components/button.scss
+++ b/packages/taro-ui/rn/style/components/button.scss
@@ -12,7 +12,7 @@
   line-height: $at-button-height - 2;
   text-align: center;
   border-radius: $border-radius-md;
-  border: 1px solid $color-border-base;
+  border: 1PX solid $color-border-base;
   margin: 0 $spacing-h-xl;
   // &:active {
   //   opacity: $opacity-active;
@@ -21,7 +21,7 @@
   /* elements */
 
   &__icon {
-    margin: 2px 20px 0 20px;
+    margin: 2PX 20px 0 20px;
   }
 
   /* modifiers */
@@ -35,12 +35,12 @@
 
   &--primary {
     color: $color-text-base-inverse;
-    border: 1px solid $at-button-border-color-primary;
+    border: 1PX solid $at-button-border-color-primary;
     background: $at-button-bg;
   }
 
   &--secondary {
-    border: 1px solid $at-button-border-color-secondary;
+    border: 1PX solid $at-button-border-color-secondary;
     background-color: $color-white;
 
     &--text {

--- a/packages/taro-ui/rn/style/components/card.scss
+++ b/packages/taro-ui/rn/style/components/card.scss
@@ -2,7 +2,7 @@
 @import '../mixins/index.scss';
 
 .at-card {
-  @include border-thin($color: $color-border-light, $width: 1px);
+  @include border-thin($color: $color-border-light, $width: 1PX);
   flex: 1;
   margin: 0 $spacing-h-lg;
   border-radius: $border-radius-lg;
@@ -12,7 +12,7 @@
   &__header {
     @include display-flex;
     @include align-items(center);
-    @include border-thin-bottom($width: 1px);
+    @include border-thin-bottom($width: 1PX);
 
     padding: $spacing-v-md $spacing-h-lg;
     position: relative;

--- a/packages/taro-ui/rn/style/components/countdown.scss
+++ b/packages/taro-ui/rn/style/components/countdown.scss
@@ -51,7 +51,7 @@
       min-width: $at-countdown-font-size;
       position: relative;
       padding: $spacing-v-xs 0;
-      border: 1px solid $color-border-grey;
+      border: 1PX solid $color-border-grey;
       border-radius: $border-radius-md;
       background-color: $at-countdown-card-num-bg-color;
 
@@ -61,7 +61,7 @@
         left: 0;
         width: 100%;
         height: 55%;
-        border-bottom-width: 1px;
+        border-bottom-width: 1PX;
         border-bottom-color: $color-grey-3;
         z-index: $zindex-divider;
       }

--- a/packages/taro-ui/rn/style/components/curtain.scss
+++ b/packages/taro-ui/rn/style/components/curtain.scss
@@ -49,7 +49,7 @@ $at-curtain-btn-size: 56px;
     bottom: -($at-curtain-btn-size + 24px);
     align-items: center;
     justify-content: center;
-    border: 2px solid $at-curtain-btn-color;
+    border: 2PX solid $at-curtain-btn-color;
     border-radius: math.div($at-curtain-btn-size, 2);
     /*  #ifndef  rn  */
     // box-sizing: border-box;

--- a/packages/taro-ui/rn/style/components/divider.scss
+++ b/packages/taro-ui/rn/style/components/divider.scss
@@ -26,7 +26,7 @@
     top: 50%;
     left: 0;
     width: 100%;
-    height: 1px;
+    height: 1PX;
     background-color: $at-divider-line-color;
     z-index: $zindex-divider;
   }

--- a/packages/taro-ui/rn/style/components/grid.scss
+++ b/packages/taro-ui/rn/style/components/grid.scss
@@ -4,7 +4,7 @@
 .at-grid {
   /* elements */
   &__flex-item {
-    border: 1px solid $color-border-light;
+    border: 1PX solid $color-border-light;
     border-top-width: 0;
     border-left-width: 0;
     // @include hairline-surround();

--- a/packages/taro-ui/rn/style/components/image-picker.scss
+++ b/packages/taro-ui/rn/style/components/image-picker.scss
@@ -52,7 +52,7 @@
     align-items: center;
     font-size: 0;
     // box-sizing: border-box;
-    @include border-thin($width: 1px);
+    @include border-thin($width: 1PX);
   }
 
   &__remove-btn {

--- a/packages/taro-ui/rn/style/components/input-number.scss
+++ b/packages/taro-ui/rn/style/components/input-number.scss
@@ -7,7 +7,7 @@ $at-input-number-btn-padding-lg: 20px;
 
 #{$component} {
   //  display: inline-flex;
-  @include border-thin($width: 1px);
+  @include border-thin($width: 1PX);
 
   display: flex;
   flex-direction: row;
@@ -49,7 +49,7 @@ $at-input-number-btn-padding-lg: 20px;
     text-align: center;
     text-align-vertical: center;
     // line-height: $line-height-zh;
-    @include border-thin($width: 1px, $directions: left right);
+    @include border-thin($width: 1PX, $directions: left right);
   }
 
   /* modifiers */

--- a/packages/taro-ui/rn/style/components/input.scss
+++ b/packages/taro-ui/rn/style/components/input.scss
@@ -9,7 +9,7 @@
   margin-left: $spacing-h-xl;
 
   /* 修复底线隐藏问题 */
-  margin-bottom: 1px;
+  margin-bottom: 1PX;
   @include hairline-bottom();
 
   &__overlay {

--- a/packages/taro-ui/rn/style/components/loading.scss
+++ b/packages/taro-ui/rn/style/components/loading.scss
@@ -23,8 +23,8 @@
     position: absolute;
     width: $at-loading-size;
     height: $at-loading-size;
-    margin: 1px;
-    border-width: 1px;
+    margin: 1PX;
+    border-width: 1PX;
     border-style: solid;
     border-color: $at-loading-color transparent transparent transparent;
     border-radius: 50%;

--- a/packages/taro-ui/rn/style/components/nav-bar.scss
+++ b/packages/taro-ui/rn/style/components/nav-bar.scss
@@ -1,10 +1,10 @@
 @import '../variables/default.scss';
 @import '../mixins/index.scss';
 
-$at-nav-bar-spacing-v: 9px;
-$at-nav-bar-spacing-h: 5px;
-$at-nav-bar-font-size: 18px;
-$at-nav-bar-back-font-size: 16px;
+$at-nav-bar-spacing-v: 9PX;
+$at-nav-bar-spacing-h: 5PX;
+$at-nav-bar-font-size: 18PX;
+$at-nav-bar-back-font-size: 16PX;
 
 .at-nav-bar {
   display: flex;

--- a/packages/taro-ui/rn/style/components/range.scss
+++ b/packages/taro-ui/rn/style/components/range.scss
@@ -4,7 +4,7 @@
 
 .at-range {
   position: relative;
-  padding: 0 math.div($at-range-slider-size, 2) + 4px;
+  padding: 0 math.div($at-range-slider-size, 2) + 4PX;
   width: 100%;
   // box-sizing: border-box;
 

--- a/packages/taro-ui/rn/style/components/search-bar.scss
+++ b/packages/taro-ui/rn/style/components/search-bar.scss
@@ -97,7 +97,7 @@ $at-search-bar-placholder-color: $color-grey-2;
     flex-direction: row;
     justify-content: center;
     align-items: center;
-    margin-left: 10px;
+    margin-left: 10PX;
     padding: 0 $at-search-bar-btn-padding;
     height: $at-search-bar-input-height;
     border-radius: 4px;

--- a/packages/taro-ui/rn/style/components/segmented-control.scss
+++ b/packages/taro-ui/rn/style/components/segmented-control.scss
@@ -10,7 +10,7 @@ $at-segmented-control-min-width: 120px;
   width: 100%;
   border-radius: $border-radius-md;
   overflow: hidden;
-  @include border-thin($color: $at-segmented-control-color, $width: 1px);
+  @include border-thin($color: $at-segmented-control-color, $width: 1PX);
 
   /* elements */
   &__item {
@@ -31,7 +31,7 @@ $at-segmented-control-min-width: 120px;
     &--plus {
       @include border-thin-left(
         $color: $at-segmented-control-color,
-        $width: 1px
+        $width: 1PX
       );
     }
   }

--- a/packages/taro-ui/rn/style/components/switch.scss
+++ b/packages/taro-ui/rn/style/components/switch.scss
@@ -11,7 +11,7 @@ $component: '.at-switch';
   background-color: $color-bg;
   margin-left: $spacing-h-xl;
   padding: $spacing-v-lg $spacing-h-xl $spacing-v-lg 0;
-  margin-bottom: 1px;
+  margin-bottom: 1PX;
 
   @include hairline-bottom();
 

--- a/packages/taro-ui/rn/style/components/tag.scss
+++ b/packages/taro-ui/rn/style/components/tag.scss
@@ -2,7 +2,7 @@
 @import '../variables/default.scss';
 @import '../mixins/index.scss';
 
-$at-tag-border-size: 1px;
+$at-tag-border-size: 1PX;
 
 .at-tag {
   padding: 0 $spacing-h-xl;

--- a/packages/taro-ui/rn/style/components/textarea.scss
+++ b/packages/taro-ui/rn/style/components/textarea.scss
@@ -13,7 +13,7 @@ $at-textarea-bg-color: $color-bg;
   border-radius: $border-radius-md;
   background-color: $at-textarea-bg-color;
   // box-sizing: border-box;
-  @include border-thin($width: 1px);
+  @include border-thin($width: 1PX);
 
   &__textarea {
     width: 100%;

--- a/packages/taro-ui/rn/style/components/timeline.scss
+++ b/packages/taro-ui/rn/style/components/timeline.scss
@@ -38,7 +38,7 @@
     border-radius: math.div($at-timeline-dot-size, 2);
     background: $at-timeline-dot-color;
     z-index: 1;
-    border: 1px solid transparent;
+    border: 1PX solid transparent;
     border-color: $at-timeline-dot-border-color;
 
     &--green {
@@ -81,7 +81,7 @@
     bottom: -1 * math.div($at-timeline-dot-size, 2);
     left: math.div($at-timeline-dot-size, 2) - 2px;
     border-left-color: $at-timeline-line-color;
-    border-left-width: 1px;
+    border-left-width: 1PX;
     border-style: solid;
   }
 }

--- a/packages/taro-ui/rn/style/mixins/libs/hairline.scss
+++ b/packages/taro-ui/rn/style/mixins/libs/hairline.scss
@@ -24,7 +24,7 @@
 @mixin hairline-surround(
   $color: $color-border-light,
   $style: solid,
-  $width: 1px
+  $width: 1PX
 ) {
   border-width: $width;
   border-color: $color;
@@ -56,7 +56,7 @@
 @mixin hairline-bottom(
   $color: $color-border-light,
   $style: solid,
-  $width: 1px
+  $width: 1PX
 ) {
   border-bottom-width: $width;
   border-bottom-color: $color;
@@ -99,7 +99,7 @@
 @mixin hairline-top-bottom(
   $color: $color-border-light,
   $style: solid,
-  $width: 1px
+  $width: 1PX
 ) {
   position: relative;
   border-top-width: $width;
@@ -111,7 +111,7 @@
 @mixin hairline-bottom-relative(
   $color: $color-border-light,
   $style: solid,
-  $width: 1px,
+  $width: 1PX,
   $left: 0
 ) {
   border-bottom-width: $width;
@@ -125,7 +125,7 @@
 @mixin hairline-top-relative(
   $color: $color-border-light,
   $style: solid,
-  $width: 1px,
+  $width: 1PX,
   $left: 0
 ) {
   border-top-width: $width;
@@ -148,7 +148,7 @@
 @mixin hairline-left-relative(
   $color: $color-border-light,
   $style: solid,
-  $width: 1px,
+  $width: 1PX,
   $top: 0
 ) {
   border-left-width: $width;
@@ -170,7 +170,7 @@
 @mixin hairline-right-relative(
   $color: $color-border-light,
   $style: solid,
-  $width: 1px,
+  $width: 1PX,
   $top: 0
 ) {
   border-right-width: $width;

--- a/packages/taro-ui/rn/style/variables/default.scss
+++ b/packages/taro-ui/rn/style/variables/default.scss
@@ -300,7 +300,7 @@ $at-list-extra-color: $color-grey-2 !default;
 $at-list-extra-width: 235px !default;
 
 /* LoadMore */
-$at-load-more-height: 80px !default;
+$at-load-more-height: 80PX !default;
 $at-load-more-tips-color: $color-grey-1 !default;
 $at-load-more-tips-size: $font-size-lg !default;
 
@@ -357,15 +357,15 @@ $at-radio-desc-size: $font-size-sm !default;
 $at-radio-check-color: $color-brand !default;
 
 /* Range */
-$at-range-slider-size: 28px !default;
-$at-range-rail-height: 2px !default;
+$at-range-slider-size: 28PX !default;
+$at-range-rail-height: 2PX !default;
 $at-range-rail-bg-color: #e9e9e9 !default;
 $at-range-track-bg-color: $color-brand !default;
 $at-range-slider-color: $color-white !default;
-$at-range-slider-shadow: 0 0 4px 0 rgba(0, 0, 0, 0.2) !default;
+$at-range-slider-shadow: 0 0 4PX 0 rgba(0, 0, 0, 0.2) !default;
 
 /* Rate */
-$at-rate-icon-size: 20px !default;
+$at-rate-icon-size: 20PX !default;
 $at-rate-star-color: #ececec !default;
 $at-rate-star-color-on: #ffca3e !default;
 
@@ -419,7 +419,7 @@ $at-tab-bar-icon-image-size: 50px !default;
 $at-tabs-color: $color-text-base !default;
 $at-tabs-color-active: $color-brand !default;
 $at-tabs-font-size: $font-size-base !default;
-$at-tabs-line-height: 1px !default;
+$at-tabs-line-height: 1PX !default;
 $at-tabs-underline-color: $color-grey-5 !default;
 $at-tabs-bg-color: $color-bg !default;
 

--- a/packages/taro-ui/src/components/countdown/index.scss
+++ b/packages/taro-ui/src/components/countdown/index.scss
@@ -48,7 +48,7 @@ $font-size: $font-size-lg;
   &--card {
     .at-count-down__time-box {
       padding: $spacing-v-xs 0;
-      border: 1px solid $color-border-grey;
+      border: 1PX solid $color-border-grey;
       border-radius: $border-radius-md;
       color: #ff4949;
       display: inline-block;
@@ -64,7 +64,7 @@ $font-size: $font-size-lg;
         position: absolute;
         content: '';
         width: 100%;
-        height: 1px;
+        height: 1PX;
         top: 50%;
         left: 0;
         z-index: $zindex-divider;

--- a/packages/taro-ui/src/style/components/badge.scss
+++ b/packages/taro-ui/src/style/components/badge.scss
@@ -31,7 +31,7 @@ $at-badge-box-shadow: 0 4px 8px 0
     position: absolute;
     padding: 0 $spacing-h-sm;
     top: -$at-badge-border-radius;
-    right: -6px;
+    right: -6PX;
     color: $at-badge-color;
     font-size: $at-badge-font-size;
     line-height: 1.4;

--- a/packages/taro-ui/src/style/components/button.scss
+++ b/packages/taro-ui/src/style/components/button.scss
@@ -21,7 +21,7 @@
   line-height: $at-button-height - 2;
   text-align: center;
   border-radius: $border-radius-md;
-  border: 1px solid $color-border-base;
+  border: 1PX solid $color-border-base;
   box-sizing: border-box;
   @include line();
 
@@ -33,7 +33,7 @@
 
   &__icon {
     display: inline-block;
-    margin: 2px 20px 0 20px;
+    margin: 2PX 20px 0 20px;
   }
 
   &__text {
@@ -73,13 +73,13 @@
 
   &--primary {
     color: $color-text-base-inverse;
-    border: 1px solid $at-button-border-color-primary;
+    border: 1PX solid $at-button-border-color-primary;
     background: $at-button-bg;
   }
 
   &--secondary {
     color: $at-button-color;
-    border: 1px solid $at-button-border-color-secondary;
+    border: 1PX solid $at-button-border-color-secondary;
     background-color: $color-white;
   }
 

--- a/packages/taro-ui/src/style/components/card.scss
+++ b/packages/taro-ui/src/style/components/card.scss
@@ -2,7 +2,7 @@
 @import '../mixins/index.scss';
 
 .at-card {
-  @include border-thin($color: $color-border-light, $width: 1px);
+  @include border-thin($color: $color-border-light, $width: 1PX);
 
   margin: 0 $spacing-h-lg;
   border-radius: $border-radius-lg;
@@ -12,7 +12,7 @@
   &__header {
     @include display-flex;
     @include align-items(center);
-    @include border-thin-bottom($width: 1px);
+    @include border-thin-bottom($width: 1PX);
 
     padding: $spacing-v-md $spacing-h-lg;
     position: relative;

--- a/packages/taro-ui/src/style/components/countdown.scss
+++ b/packages/taro-ui/src/style/components/countdown.scss
@@ -53,7 +53,7 @@
       position: relative;
       padding: $spacing-v-xs 0;
       color: $at-countdown-card-num-color;
-      border: 1px solid $color-border-grey;
+      border: 1PX solid $color-border-grey;
       border-radius: $border-radius-md;
       background-color: $at-countdown-card-num-bg-color;
 
@@ -68,7 +68,7 @@
         top: 50%;
         left: 0;
         width: 100%;
-        height: 1px;
+        height: 1PX;
         background-color: $color-grey-3;
         z-index: $zindex-divider;
       }

--- a/packages/taro-ui/src/style/components/curtain.scss
+++ b/packages/taro-ui/src/style/components/curtain.scss
@@ -41,7 +41,7 @@ $at-curtain-btn-size: 56px;
     bottom: -($at-curtain-btn-size + 24px);
     align-items: center;
     justify-content: center;
-    border: 2px solid $at-curtain-btn-color;
+    border: 2PX solid $at-curtain-btn-color;
     border-radius: 50%;
     box-sizing: border-box;
     z-index: $zindex-curtain;
@@ -54,8 +54,8 @@ $at-curtain-btn-size: 56px;
       left: 50%;
       display: inline-block;
       width: 34px;
-      height: 2px;
-      border-radius: 1px;
+      height: 2PX;
+      border-radius: 1PX;
       background: $at-curtain-btn-color;
     }
 

--- a/packages/taro-ui/src/style/components/divider.scss
+++ b/packages/taro-ui/src/style/components/divider.scss
@@ -27,7 +27,7 @@
     top: 50%;
     left: 0;
     width: 100%;
-    height: 1px;
+    height: 1PX;
     background-color: $at-divider-line-color;
     z-index: $zindex-divider;
   }

--- a/packages/taro-ui/src/style/components/float-layout.scss
+++ b/packages/taro-ui/src/style/components/float-layout.scss
@@ -66,8 +66,8 @@ $float-layout-timer: 300ms;
           left: 50%;
           display: inline-block;
           width: 36px;
-          height: 2px;
-          border-radius: 1px;
+          height: 2PX;
+          border-radius: 1PX;
           background: $float-layout-btn-color;
         }
 

--- a/packages/taro-ui/src/style/components/image-picker.scss
+++ b/packages/taro-ui/src/style/components/image-picker.scss
@@ -45,7 +45,7 @@
     align-items: center;
     font-size: 0;
     box-sizing: border-box;
-    @include border-thin($width: 1px);
+    @include border-thin($width: 1PX);
 
     .add-bar {
       position: absolute;
@@ -53,8 +53,8 @@
       left: 50%;
       display: inline-block;
       width: 60px;
-      height: 2px;
-      border-radius: 1px;
+      height: 2PX;
+      border-radius: 1PX;
       background: $at-image-picker-btn-add-color;
 
       &:nth-child(1) {
@@ -72,11 +72,11 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    top: 6px;
-    right: 6px;
+    top: 6PX;
+    right: 6PX;
     z-index: 2;
-    width: 18px;
-    height: 18px;
+    width: 18PX;
+    height: 18PX;
     font-size: 0;
     border-radius: 50%;
     overflow: hidden;
@@ -92,9 +92,9 @@
       top: 50%;
       left: 50%;
       display: inline-block;
-      width: 10px;
-      height: 1px;
-      border-radius: 1px;
+      width: 10PX;
+      height: 1PX;
+      border-radius: 1PX;
       background: $at-image-picker-btn-remove-color;
     }
 

--- a/packages/taro-ui/src/style/components/input-number.scss
+++ b/packages/taro-ui/src/style/components/input-number.scss
@@ -7,7 +7,7 @@ $at-input-number-btn-padding-lg: 20px;
 
 #{$component} {
   display: inline-flex;
-  @include border-thin($width: 1px);
+  @include border-thin($width: 1PX);
 
   font-size: $at-input-number-font-size;
   border-radius: $border-radius-md;
@@ -45,7 +45,7 @@ $at-input-number-btn-padding-lg: 20px;
     font-size: $at-input-number-font-size;
     text-align: center;
     align-items: center;
-    @include border-thin($width: 1px, $directions: left right);
+    @include border-thin($width: 1PX, $directions: left right);
   }
 
   /* modifiers */

--- a/packages/taro-ui/src/style/components/input.scss
+++ b/packages/taro-ui/src/style/components/input.scss
@@ -9,7 +9,7 @@
   margin-left: $spacing-h-xl;
 
   /* 修复底线隐藏问题 */
-  margin-bottom: 1px;
+  margin-bottom: 1PX;
   @include hairline-bottom();
 
   &__overlay {

--- a/packages/taro-ui/src/style/components/loading.scss
+++ b/packages/taro-ui/src/style/components/loading.scss
@@ -23,8 +23,8 @@
     position: absolute;
     width: $at-loading-size;
     height: $at-loading-size;
-    margin: 1px;
-    border-width: 1px;
+    margin: 1PX;
+    border-width: 1PX;
     border-style: solid;
     border-color: $at-loading-color transparent transparent transparent;
     border-radius: 50%;

--- a/packages/taro-ui/src/style/components/nav-bar.scss
+++ b/packages/taro-ui/src/style/components/nav-bar.scss
@@ -1,10 +1,10 @@
 @import '../variables/default.scss';
 @import '../mixins/index.scss';
 
-$at-nav-bar-spacing-v: 9px;
-$at-nav-bar-spacing-h: 5px;
-$at-nav-bar-font-size: 18px;
-$at-nav-bar-back-font-size: 16px;
+$at-nav-bar-spacing-v: 9PX;
+$at-nav-bar-spacing-h: 5PX;
+$at-nav-bar-font-size: 18PX;
+$at-nav-bar-back-font-size: 16PX;
 
 .at-nav-bar {
   display: flex;

--- a/packages/taro-ui/src/style/components/range.scss
+++ b/packages/taro-ui/src/style/components/range.scss
@@ -3,7 +3,7 @@
 
 .at-range {
   position: relative;
-  padding: 0 calc($at-range-slider-size / 2 + 4px);
+  padding: 0 calc($at-range-slider-size / 2 + 4PX);
   width: 100%;
   box-sizing: border-box;
 

--- a/packages/taro-ui/src/style/components/search-bar.scss
+++ b/packages/taro-ui/src/style/components/search-bar.scss
@@ -2,11 +2,11 @@
 @import '../variables/default.scss';
 @import '../mixins/index.scss';
 
-$at-search-bar-font-size: 14px;
-$at-search-bar-input-height: 30px;
-$at-search-bar-input-padding: 25px;
-$at-search-bar-btn-padding: 10px;
-$at-search-bar-placeholder-padding: 12px;
+$at-search-bar-font-size: 14PX;
+$at-search-bar-input-height: 30PX;
+$at-search-bar-input-padding: 25PX;
+$at-search-bar-btn-padding: 10PX;
+$at-search-bar-placeholder-padding: 12PX;
 $at-search-bar-input-bg-color: $color-bg-grey;
 $at-search-bar-input-color: $color-black-0;
 $at-search-bar-placholder-color: $color-grey-2;
@@ -98,13 +98,13 @@ $at-search-bar-placholder-color: $color-grey-2;
   &__action {
     flex: none;
     display: block;
-    margin-left: 10px;
+    margin-left: 10PX;
     padding: 0 $at-search-bar-btn-padding;
     height: $at-search-bar-input-height;
     color: $at-search-bar-btn-color;
     font-size: $at-search-bar-font-size;
     line-height: $at-search-bar-input-height;
-    border-radius: 4px;
+    border-radius: 4PX;
     background-color: $at-search-bar-btn-bg-color;
     transition: margin-right 0.3s, opacity 0.3s;
     opacity: 0;

--- a/packages/taro-ui/src/style/components/segmented-control.scss
+++ b/packages/taro-ui/src/style/components/segmented-control.scss
@@ -12,7 +12,7 @@ $at-segmented-control-min-width: 120px;
   box-sizing: border-box;
   white-space: nowrap;
   overflow: hidden;
-  @include border-thin($color: $at-segmented-control-color, $width: 1px);
+  @include border-thin($color: $at-segmented-control-color, $width: 1PX);
 
   /* elements */
   &__item {
@@ -35,7 +35,7 @@ $at-segmented-control-min-width: 120px;
   }
 
   &__item + &__item {
-    @include border-thin-left($color: $at-segmented-control-color, $width: 1px);
+    @include border-thin-left($color: $at-segmented-control-color, $width: 1PX);
   }
 
   /* modifiers */

--- a/packages/taro-ui/src/style/components/switch.scss
+++ b/packages/taro-ui/src/style/components/switch.scss
@@ -10,7 +10,7 @@ $component: '.at-switch';
   background-color: $color-bg;
   margin-left: $spacing-h-xl;
   padding: $spacing-v-lg $spacing-h-xl $spacing-v-lg 0;
-  margin-bottom: 1px;
+  margin-bottom: 1PX;
   @include hairline-bottom();
 
   /* elements */

--- a/packages/taro-ui/src/style/components/tag.scss
+++ b/packages/taro-ui/src/style/components/tag.scss
@@ -2,7 +2,7 @@
 @import '../variables/default.scss';
 @import '../mixins/index.scss';
 
-$at-tag-border-size: 1px;
+$at-tag-border-size: 1PX;
 
 .at-tag {
   display: inline-block;

--- a/packages/taro-ui/src/style/components/textarea.scss
+++ b/packages/taro-ui/src/style/components/textarea.scss
@@ -13,7 +13,7 @@ $at-textarea-bg-color: $color-bg;
   border-radius: $border-radius-md;
   background-color: $at-textarea-bg-color;
   box-sizing: border-box;
-  @include border-thin($width: 1px);
+  @include border-thin($width: 1PX);
 
   &__textarea {
     width: 100%;

--- a/packages/taro-ui/src/style/components/timeline.scss
+++ b/packages/taro-ui/src/style/components/timeline.scss
@@ -48,7 +48,7 @@
       box-sizing: border-box;
       width: $at-timeline-dot-size;
       height: $at-timeline-dot-size;
-      border: 1px solid transparent;
+      border: 1PX solid transparent;
       border-radius: $border-radius-circle;
       border-color: $at-timeline-dot-border-color;
     }
@@ -69,7 +69,7 @@
     top: calc($at-timeline-dot-size / 2);
     bottom: calc($at-timeline-dot-size / -2);
     left: calc($at-timeline-dot-size / 2) - 2px;
-    border-left: 1px solid $at-timeline-line-color;
+    border-left: 1PX solid $at-timeline-line-color;
   }
 
   /* modifiers */

--- a/packages/taro-ui/src/style/mixins/libs/hairline.scss
+++ b/packages/taro-ui/src/style/mixins/libs/hairline.scss
@@ -24,7 +24,7 @@
 @mixin hairline-surround(
   $color: $color-border-light,
   $style: solid,
-  $width: 1px
+  $width: 1PX
 ) {
   position: relative;
 
@@ -48,7 +48,7 @@
 @mixin hairline-bottom(
   $color: $color-border-light,
   $style: solid,
-  $width: 1px
+  $width: 1PX
 ) {
   position: relative;
 
@@ -82,7 +82,7 @@
 @mixin hairline-top-bottom(
   $color: $color-border-light,
   $style: solid,
-  $width: 1px
+  $width: 1PX
 ) {
   position: relative;
 
@@ -97,7 +97,7 @@
 @mixin hairline-bottom-relative(
   $color: $color-border-light,
   $style: solid,
-  $width: 1px,
+  $width: 1PX,
   $left: 0
 ) {
   position: relative;
@@ -117,7 +117,7 @@
 @mixin hairline-top-relative(
   $color: $color-border-light,
   $style: solid,
-  $width: 1px,
+  $width: 1PX,
   $left: 0
 ) {
   position: relative;
@@ -137,7 +137,7 @@
 @mixin hairline-left-relative(
   $color: $color-border-light,
   $style: solid,
-  $width: 1px,
+  $width: 1PX,
   $top: 0
 ) {
   position: relative;
@@ -157,7 +157,7 @@
 @mixin hairline-right-relative(
   $color: $color-border-light,
   $style: solid,
-  $width: 1px,
+  $width: 1PX,
   $top: 0
 ) {
   position: relative;

--- a/packages/taro-ui/src/style/variables/default.scss
+++ b/packages/taro-ui/src/style/variables/default.scss
@@ -296,7 +296,7 @@ $at-list-extra-color: $color-grey-2 !default;
 $at-list-extra-width: 235px !default;
 
 /* LoadMore */
-$at-load-more-height: 80px !default;
+$at-load-more-height: 80PX !default;
 $at-load-more-tips-color: $color-grey-1 !default;
 $at-load-more-tips-size: $font-size-lg !default;
 
@@ -353,15 +353,15 @@ $at-radio-desc-size: $font-size-sm !default;
 $at-radio-check-color: $color-brand !default;
 
 /* Range */
-$at-range-slider-size: 28px !default;
-$at-range-rail-height: 2px !default;
+$at-range-slider-size: 28PX !default;
+$at-range-rail-height: 2PX !default;
 $at-range-rail-bg-color: #e9e9e9 !default;
 $at-range-track-bg-color: $color-brand !default;
 $at-range-slider-color: $color-white !default;
-$at-range-slider-shadow: 0 0 4px 0 rgba(0, 0, 0, 0.2) !default;
+$at-range-slider-shadow: 0 0 4PX 0 rgba(0, 0, 0, 0.2) !default;
 
 /* Rate */
-$at-rate-icon-size: 20px !default;
+$at-rate-icon-size: 20PX !default;
 $at-rate-star-color: #ececec !default;
 $at-rate-star-color-on: #ffca3e !default;
 
@@ -415,7 +415,7 @@ $at-tab-bar-icon-image-size: 50px !default;
 $at-tabs-color: $color-text-base !default;
 $at-tabs-color-active: $color-brand !default;
 $at-tabs-font-size: $font-size-base !default;
-$at-tabs-line-height: 1px !default;
+$at-tabs-line-height: 1PX !default;
 $at-tabs-underline-color: $color-grey-5 !default;
 $at-tabs-bg-color: $color-bg !default;
 


### PR DESCRIPTION
提交 #1893 在全仓库 Prettier 格式化时把 Taro 中有特殊语义的 `PX`（跳过 pxtransform）误改为 `px`（按设计稿比例转换），改变了组件视觉表现。

以 `v3.3.3` 为基准还原 `packages/taro-ui/src/style` 与 `rn/style` 下所有受影响的 `PX` 单位，包括：

- `variables/default.scss` 组件变量
- `hairline.scss` mixin 默认 `$width`
- 各组件 scss 中的固定像素值

`badge.scss` 仅还原 `__num`（`__dot` 原本即为 `px`）；inline TSX/TS 样式经核对未受影响。

归一化 diff 校验确认所有改动均为纯 `px` → `PX` 大小写还原，未引入其他格式或逻辑变更。