### PR TITLE
chore(repo): stale bot and maintenance policy

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,60 @@
+# Auto-triage inactive issues and PRs after repo maintenance resumed (2026).
+# Policy: docs/MAINTENANCE.md
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+    # Daily 03:17 UTC
+    - cron: '17 3 * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-issue-stale: 180
+          days-before-issue-close: 30
+          days-before-pr-stale: 90
+          days-before-pr-close: 14
+          stale-issue-label: 'stale'
+          stale-pr-label: 'stale'
+          ascending: true
+          operations-per-run: 60
+          remove-stale-when-updated: true
+          enable-statistics: true
+
+          stale-issue-message: |
+            本 issue 已超过 **180 天** 无活动。
+
+            仓库已恢复维护，主线为 **Taro 3.x + taro-ui 3.x**。为清理历史列表，将标记为 stale。
+            - 若问题在 **最新 taro-ui** 仍存在：请评论补充版本、`taro info`、复现步骤，或重新打开并更新信息。
+            - 若不再相关：无需操作，将在约 **30 天后** 自动关闭。
+
+            维护说明：见仓库 `docs/MAINTENANCE.md`。
+
+          close-issue-message: |
+            因长期无活动自动关闭。
+
+            若问题在最新版仍可复现，请 **新开 issue**（附版本与最小复现）或评论请求 reopen。感谢理解。
+
+          stale-pr-message: |
+            本 PR 已超过 **90 天** 无活动。
+
+            主线已大幅变更（构建 / Taro 3 / 目录结构）。若仍希望合入，请基于 `next` rebase 并评论说明；
+            否则将在约 **14 天后** 自动关闭。
+
+          close-pr-message: |
+            因长期无活动自动关闭。如仍有价值，请基于最新 `next` 重新提交 PR。感谢贡献。
+
+          # Do not stale actively tracked work
+          exempt-issue-labels: 'pinned,security,fixed but not released,waiting taro fix,iron-tree:adopted,stage:task,stage:run,stage:verify'
+          exempt-pr-labels: 'pinned,security'
+          exempt-all-milestones: false
+          exempt-all-assignees: true

--- a/docs/MAINTENANCE.md
+++ b/docs/MAINTENANCE.md
@@ -1,0 +1,50 @@
+# 仓库维护与历史 Issue / PR 治理
+
+> 目标：在恢复维护后，把主列表收敛到「当前主线仍相关」的事项，而不是清空社区记录。
+
+## 当前主线
+
+- **Taro**：3.x（见 `peerDependencies`）
+- **分支**：开发与发布以 `next` 为主（发布流程见 `.github/workflows/publish.yml`）
+- **包**：`packages/taro-ui`（npm 包名 `taro-ui`）
+
+不在当前主线范围的内容（示例）：Taro 1.x / 2.x 专用问题、已废弃构建链、长期无主线计划的端（如历史快应用移植实验）等，将优先关闭或标记 `wontfix`。
+
+## Issue 策略
+
+| 类型 | 处理 |
+|------|------|
+| 最新版可复现的 bug | 保留，补标签与版本信息 |
+| 符合 ROADMAP 的 enhancement | 保留或链到 ROADMAP issue |
+| 提问 / 用法 | 回答后关闭，或标 `answered` |
+| \>180 天无活动 | 由 [stale 工作流](../.github/workflows/stale.yml) 标记，再 30 天后关闭 |
+| 明确过时 / 无法复现 / 超出范围 | 人工关闭并说明原因 |
+
+关闭历史 issue **不是拒绝反馈**：可在新版本上 **新开 issue** 或评论请求 reopen。
+
+### 推荐标签
+
+- `bug` / `enhancement` / `question`
+- `需要复现` / `信息不足` / `to be closed` / `wontfix`
+- `fixed but not released` / `waiting taro fix`
+- 组件类标签（表单 / 布局 / …）
+
+## PR 策略
+
+| 类型 | 处理 |
+|------|------|
+| 基于 `dev` 等旧分支、长期无更新 | 关闭，请基于 `next` 重开 |
+| 依赖 bot 且路径/主线已变 | 关闭，由当前依赖策略重开 |
+| 仍有价值但冲突大 | 关闭并转为 issue，或请作者 rebase 到 `next` |
+| 小修复且仍适用 | 邀请 rebase；超时无响应则维护者自行评估 cherry-pick 或关闭 |
+
+## 自动化
+
+- **Stale bot**：`.github/workflows/stale.yml`（可 `workflow_dispatch` 手动跑）
+- Issue：180 天 stale → 30 天关闭  
+- PR：90 天 stale → 14 天关闭  
+- 已指派 assignee 的 issue/PR 豁免；带豁免标签的不处理  
+
+## 人工批量清理（一次性）
+
+恢复维护初期可对 **创建 ≥2 年且长期无活动** 的条目做公告后分批关闭；话术与公告见维护公告 issue（标题含「仓库维护公告」）。


### PR DESCRIPTION
## Summary
- Add `actions/stale` workflow for inactive issues/PRs
- Document repo hygiene in `docs/MAINTENANCE.md`
- Related announcement: #1905

## Test plan
- [x] Workflow YAML validates
- [ ] After merge, optionally run workflow_dispatch once