### PR TITLE
feat: implement historical PR backlog (#1907)

### DIFF
--- a/packages/taro-ui/src/components/accordion/index.tsx
+++ b/packages/taro-ui/src/components/accordion/index.tsx
@@ -20,7 +20,8 @@ function AtAccordion({
 }: AtAccordionProps): JSX.Element {
   const isCompletedRef = useRef(true)
   const [componentId] = useState(() => uuid())
-  const [wrapperHeight, setWrapperHeight] = useState(0)
+  // 使用 null 表示 auto 高度，避免默认 open 时 height:0 触发错误动画
+  const [wrapperHeight, setWrapperHeight] = useState<number | null>(null)
   const [startOpen, setStartOpen] = useState(false)
   const [, setRenderEpoch] = useState(0)
   const prevOpenRef = useRef(open)
@@ -31,7 +32,7 @@ function AtAccordion({
     isCompletedRef.current = false
 
     delayQuerySelector(`#at-accordion__body-${componentId}`, 0).then(rect => {
-      const height = parseInt(rect[0].height.toString())
+      const height = parseInt(rect[0].height.toString()) || 0
       const startHeight = wasOpen ? height : 0
       const endHeight = wasOpen ? 0 : height
       setStartOpen(false)
@@ -40,6 +41,7 @@ function AtAccordion({
         setWrapperHeight(endHeight)
         setTimeout(() => {
           isCompletedRef.current = true
+          setWrapperHeight(null)
           setRenderEpoch(epoch => epoch + 1)
         }, 700)
       }, 100)
@@ -48,7 +50,8 @@ function AtAccordion({
 
   useLayoutEffect(() => {
     if (prevOpenRef.current !== open) {
-      setStartOpen(!!open && !!isAnimation)
+      // 仅在「从未展开 → 展开」时标记 startOpen，避免默认 open 首帧误动画
+      setStartOpen(!!open && !prevOpenRef.current && !!isAnimation)
       toggleWithAnimation(prevOpenRef.current)
       prevOpenRef.current = open
     }
@@ -81,10 +84,9 @@ function AtAccordion({
     color: (icon && icon.color) || '',
     fontSize: (icon && `${icon.size}px`) || ''
   }
-  const contentStyle: { height?: string } = { height: `${wrapperHeight}px` }
-
-  if (isCompletedRef.current) {
-    contentStyle.height = ''
+  const contentStyle: { height?: string } = {}
+  if (!isCompletedRef.current && wrapperHeight !== null) {
+    contentStyle.height = `${wrapperHeight}px`
   }
 
   return (

--- a/packages/taro-ui/src/components/calendar/body/index.tsx
+++ b/packages/taro-ui/src/components/calendar/body/index.tsx
@@ -30,6 +30,7 @@ function AtCalendarBody({
   validDates,
   minDate,
   maxDate,
+  disabledDate,
   selectedDates,
   isSwiper,
   isVertical,
@@ -51,6 +52,7 @@ function AtCalendarBody({
       format,
       minDate,
       maxDate,
+      disabledDate,
       marks,
       selectedDates
     })
@@ -119,6 +121,7 @@ function AtCalendarBody({
       format,
       minDate,
       maxDate,
+      disabledDate,
       marks,
       selectedDates
     })
@@ -132,6 +135,7 @@ function AtCalendarBody({
     format,
     minDate,
     maxDate,
+    disabledDate,
     generateDate,
     selectedDate,
     selectedDates

--- a/packages/taro-ui/src/components/calendar/common/plugins.ts
+++ b/packages/taro-ui/src/components/calendar/common/plugins.ts
@@ -88,14 +88,18 @@ export function handleDisabled(
 ): Calendar.Item {
   const { options } = args
   const { _value } = item
-  const { minDate, maxDate } = options
+  const { minDate, maxDate, disabledDate } = options
 
   const dayjsMinDate = dayjs(minDate)
   const dayjsMaxDate = dayjs(maxDate)
 
   item.isDisabled =
-    !!(minDate && _value?.isBefore(dayjsMinDate)) ||
-    !!(maxDate && _value?.isAfter(dayjsMaxDate))
+    !!(minDate && _value?.isBefore(dayjsMinDate.startOf('day'))) ||
+    !!(maxDate && _value?.isAfter(dayjsMaxDate.startOf('day')))
+
+  if (!item.isDisabled && typeof disabledDate === 'function' && _value) {
+    item.isDisabled = !!disabledDate(_value)
+  }
 
   return item
 }

--- a/packages/taro-ui/src/components/calendar/index.tsx
+++ b/packages/taro-ui/src/components/calendar/index.tsx
@@ -28,6 +28,7 @@ function AtCalendar(props: AtCalendarProps): JSX.Element {
     monthFormat,
     minDate,
     maxDate,
+    disabledDate,
     className,
     onMonthChange,
     onClickPreMonth,
@@ -222,6 +223,33 @@ function AtCalendar(props: AtCalendarProps): JSX.Element {
     return stateValue
   }
 
+  const isDateDisabled = (date: Dayjs): boolean => {
+    const day = date.startOf('day')
+    if (minDate && day.isBefore(dayjs(minDate).startOf('day'))) return true
+    if (maxDate && day.isAfter(dayjs(maxDate).startOf('day'))) return true
+    if (validDates && validDates.length > 0) {
+      const included = validDates.some(d =>
+        dayjs(d.value).startOf('day').isSame(day)
+      )
+      if (!included) return true
+    }
+    if (typeof disabledDate === 'function' && disabledDate(day)) return true
+    return false
+  }
+
+  const rangeHasDisabledDate = (
+    startUnix: number,
+    endUnix: number
+  ): boolean => {
+    let cursor = dayjs(Math.min(startUnix, endUnix)).startOf('day')
+    const end = dayjs(Math.max(startUnix, endUnix)).startOf('day')
+    while (cursor.isBefore(end) || cursor.isSame(end)) {
+      if (isDateDisabled(cursor)) return true
+      cursor = cursor.add(1, 'day')
+    }
+    return false
+  }
+
   const getMultiSelectedState = (
     value: Dayjs,
     currentSelectedDate: Calendar.SelectedDate
@@ -236,10 +264,17 @@ function AtCalendar(props: AtCalendarProps): JSX.Element {
     if (end) {
       state.selectedDate = getSelectedDate(valueUnix, 0)
     } else {
-      state.selectedDate = {
-        ...currentSelectedDate,
-        end: Math.max(valueUnix, +start),
-        start: Math.min(valueUnix, +start)
+      const nextStart = Math.min(valueUnix, +start)
+      const nextEnd = Math.max(valueUnix, +start)
+      // 多选区间不得跨越不可选日期
+      if (rangeHasDisabledDate(nextStart, nextEnd)) {
+        state.selectedDate = getSelectedDate(valueUnix, 0)
+      } else {
+        state.selectedDate = {
+          ...currentSelectedDate,
+          end: nextEnd,
+          start: nextStart
+        }
       }
     }
 
@@ -298,6 +333,7 @@ function AtCalendar(props: AtCalendarProps): JSX.Element {
         format={format}
         minDate={minDate}
         maxDate={maxDate}
+        disabledDate={disabledDate}
         isSwiper={isSwiper}
         isVertical={isVertical}
         selectedDate={selectedDate}

--- a/packages/taro-ui/src/components/checkbox/index.tsx
+++ b/packages/taro-ui/src/components/checkbox/index.tsx
@@ -2,7 +2,7 @@ import classNames from 'classnames'
 import PropTypes from 'prop-types'
 import React from 'react'
 import { Text, View } from '@tarojs/components'
-import { AtCheckboxProps } from '../../../types/checkbox'
+import { AtCheckboxProps, CheckboxOption } from '../../../types/checkbox'
 import { noop } from '../../common/utils'
 
 function AtCheckbox({
@@ -12,8 +12,7 @@ function AtCheckbox({
   selectedList = [],
   onChange = noop
 }: AtCheckboxProps<any>): JSX.Element {
-  const handleClick = (idx: number): void => {
-    const option = options[idx]
+  const handleClick = (option: CheckboxOption<any>): void => {
     const { disabled, value } = option
     if (disabled) return
 
@@ -23,14 +22,14 @@ function AtCheckbox({
     } else {
       selectedSet.delete(value)
     }
-    onChange([...selectedSet])
+    onChange([...selectedSet], value)
   }
 
   const rootCls = classNames('at-checkbox', className)
 
   return (
     <View className={rootCls} style={customStyle}>
-      {options.map((option, idx) => {
+      {options.map(option => {
         const { value, disabled, label, desc } = option
         const optionCls = classNames('at-checkbox__option', {
           'at-checkbox__option--disabled': disabled,
@@ -41,7 +40,7 @@ function AtCheckbox({
           <View
             className={optionCls}
             key={value}
-            onClick={() => handleClick(idx)}
+            onClick={() => handleClick(option)}
           >
             <View className='at-checkbox__option-wrap'>
               <View className='at-checkbox__option-cnt'>

--- a/packages/taro-ui/src/components/drawer/index.tsx
+++ b/packages/taro-ui/src/components/drawer/index.tsx
@@ -2,6 +2,7 @@ import classNames from 'classnames'
 import PropTypes from 'prop-types'
 import React, { useEffect, useRef, useState } from 'react'
 import { View } from '@tarojs/components'
+import { CommonEvent } from '@tarojs/components/types/common'
 import { AtDrawerProps } from '../../../types/drawer'
 import AtList from '../list/index'
 import AtListItem from '../list/item/index'
@@ -86,6 +87,11 @@ function AtDrawer({
     animHide()
   }
 
+  const onMaskTouchMove = (e: CommonEvent): void => {
+    // 阻止遮罩下页面滚动/点击穿透
+    e.stopPropagation()
+  }
+
   const maskStyle = {
     display: mask ? 'block' : 'none',
     opacity: animShow ? 1 : 0
@@ -109,6 +115,8 @@ function AtDrawer({
         className='at-drawer__mask'
         style={maskStyle}
         onClick={onMaskClick}
+        onTouchMove={onMaskTouchMove}
+        catchMove
       ></View>
 
       <View className='at-drawer__content' style={listStyle}>

--- a/packages/taro-ui/src/components/float-layout/index.tsx
+++ b/packages/taro-ui/src/components/float-layout/index.tsx
@@ -16,6 +16,8 @@ function AtFloatLayout({
   scrollLeft,
   upperThreshold,
   lowerThreshold,
+  closeOnClickOverlay = true,
+  position = 'bottom',
   className,
   children,
   onClose,
@@ -45,6 +47,12 @@ function AtFloatLayout({
     handleClose(e)
   }
 
+  const handleOverlayClick = (e): void => {
+    if (closeOnClickOverlay) {
+      close(e)
+    }
+  }
+
   const handleTouchMove = (e: CommonEvent): void => {
     e.stopPropagation()
   }
@@ -52,14 +60,15 @@ function AtFloatLayout({
   const rootClass = classNames(
     'at-float-layout',
     {
-      'at-float-layout--active': _isOpened
+      'at-float-layout--active': _isOpened,
+      'at-float-layout--top': position === 'top'
     },
     className
   )
 
   return (
     <View className={rootClass} onTouchMove={handleTouchMove}>
-      <View onClick={close} className='at-float-layout__overlay' />
+      <View onClick={handleOverlayClick} className='at-float-layout__overlay' />
       <View className='at-float-layout__container layout'>
         {title ? (
           <View className='layout-header'>
@@ -99,6 +108,8 @@ AtFloatLayout.propTypes = {
   upperThreshold: PropTypes.number,
   lowerThreshold: PropTypes.number,
   scrollWithAnimation: PropTypes.bool,
+  closeOnClickOverlay: PropTypes.bool,
+  position: PropTypes.oneOf(['top', 'bottom']),
   onClose: PropTypes.func,
   onScroll: PropTypes.func,
   onScrollToLower: PropTypes.func,

--- a/packages/taro-ui/src/components/icon/index.tsx
+++ b/packages/taro-ui/src/components/icon/index.tsx
@@ -2,6 +2,7 @@ import classNames from 'classnames'
 import PropTypes from 'prop-types'
 import React from 'react'
 import { Text } from '@tarojs/components'
+import { CommonEvent } from '@tarojs/components/types/common'
 import { AtIconProps } from '../../../types/icon'
 import { mergeStyle, pxTransform } from '../../common/utils'
 
@@ -14,8 +15,8 @@ export default function AtIcon({
   size = 24,
   onClick
 }: AtIconProps): JSX.Element {
-  function handleClick(): void {
-    onClick && onClick(arguments as any)
+  function handleClick(event: CommonEvent): void {
+    onClick && onClick(event)
   }
 
   const rootStyle = {

--- a/packages/taro-ui/src/components/input-number/index.tsx
+++ b/packages/taro-ui/src/components/input-number/index.tsx
@@ -49,6 +49,7 @@ function AtInputNumber({
   className = '',
   disabled = false,
   disabledInput = false,
+  changeOnBlur = false,
   type = 'number',
   width = 0,
   min = 0,
@@ -127,11 +128,31 @@ function AtInputNumber({
     if (disabled) return ''
 
     const newValue = handleValue(inputVal)
-    onChange(Number(newValue), e)
+    if (!changeOnBlur) {
+      onChange(Number(newValue), e)
+    }
     return newValue
   }
 
-  const handleBlur = (event: ITouchEvent): void => onBlur && onBlur(event)
+  const handleBlur = (event: ITouchEvent): void => {
+    if (changeOnBlur && !disabled) {
+      const target = event.target as unknown as { value?: string | number }
+      const detail = (
+        event as unknown as { detail?: { value?: string | number } }
+      ).detail
+      let raw: string | number | null = null
+      if (target && typeof target.value !== 'undefined') {
+        raw = target.value
+      } else if (detail && typeof detail.value !== 'undefined') {
+        raw = detail.value
+      }
+      if (raw !== null) {
+        const newValue = handleValue(raw)
+        onChange(Number(newValue), event as unknown as CommonEvent)
+      }
+    }
+    onBlur && onBlur(event)
+  }
 
   const inputStyle = {
     width: width ? `${pxTransform(width)}` : ''
@@ -193,6 +214,7 @@ AtInputNumber.propTypes = {
   step: PropTypes.number,
   size: PropTypes.oneOf(['normal', 'large']),
   disabledInput: PropTypes.bool,
+  changeOnBlur: PropTypes.bool,
   onChange: PropTypes.func,
   onBlur: PropTypes.func,
   onErrorInput: PropTypes.func

--- a/packages/taro-ui/src/style/components/float-layout.scss
+++ b/packages/taro-ui/src/style/components/float-layout.scss
@@ -32,6 +32,14 @@ $float-layout-timer: 300ms;
     transition: transform $float-layout-timer cubic-bezier(0.36, 0.66, 0.04, 1);
   }
 
+  &--top {
+    .at-float-layout__container {
+      top: 0;
+      bottom: auto;
+      transform: translate3d(0, -100%, 0);
+    }
+  }
+
   .layout {
     &-header {
       position: relative;
@@ -102,6 +110,12 @@ $float-layout-timer: 300ms;
       opacity: 1;
     }
 
+    .at-float-layout__container {
+      transform: translate3d(0, 0, 0);
+    }
+  }
+
+  &--top#{&}--active {
     .at-float-layout__container {
       transform: translate3d(0, 0, 0);
     }

--- a/packages/taro-ui/src/style/components/frozen.scss
+++ b/packages/taro-ui/src/style/components/frozen.scss
@@ -1,0 +1,8 @@
+/**
+ * H5: lock page scroll when modal / float-layout is open
+ * (class toggled on document.body via handleTouchScroll)
+ */
+.at-frozen {
+  position: fixed;
+  width: 100%;
+}

--- a/packages/taro-ui/src/style/components/index.scss
+++ b/packages/taro-ui/src/style/components/index.scss
@@ -2,6 +2,7 @@
  * Components
  */
 
+@import 'frozen.scss';
 @import 'icon.scss';
 @import 'flex.scss';
 @import 'accordion.scss';

--- a/packages/taro-ui/test/components/checkbox.test.js
+++ b/packages/taro-ui/test/components/checkbox.test.js
@@ -58,6 +58,7 @@ describe('AtCheckbox Event', () => {
     fireEvent.click(items[0])
     expect(onClick).toBeCalled()
     expect(onClick.mock.calls[0][0]).toEqual(['list2', 'list1'])
+    expect(onClick.mock.calls[0][1]).toEqual('list1')
   })
 
   it('AtCheckbox disabled, onChange not to be called', () => {

--- a/packages/taro-ui/test/components/float-layout.test.js
+++ b/packages/taro-ui/test/components/float-layout.test.js
@@ -57,4 +57,34 @@ describe('FloatLayout Behavior ', () => {
       expect(onClose).toBeCalled()
     })
   })
+
+  it('FloatLayout closeOnClickOverlay=false does not close', async () => {
+    const onClose = jest.fn()
+
+    const { container } = render(
+      <AtFloatLayout
+        isOpened
+        title='这是个标题'
+        closeOnClickOverlay={false}
+        onClose={onClose}
+      >
+        content
+      </AtFloatLayout>
+    )
+    const componentDom = queryByClass(container, 'at-float-layout')
+    const overlayDom = componentDom.querySelector('.at-float-layout__overlay')
+
+    fireEvent.click(overlayDom)
+    expect(onClose).not.toBeCalled()
+  })
+
+  it('FloatLayout position=top applies modifier class', () => {
+    const { container } = render(
+      <AtFloatLayout isOpened position='top'>
+        content
+      </AtFloatLayout>
+    )
+    const componentDom = queryByClass(container, 'at-float-layout')
+    expect(componentDom.className).toContain('at-float-layout--top')
+  })
 })

--- a/packages/taro-ui/types/calendar.d.ts
+++ b/packages/taro-ui/types/calendar.d.ts
@@ -64,6 +64,11 @@ declare namespace Calendar {
     minDate?: DateArg
 
     maxDate?: DateArg
+
+    /**
+     * 自定义禁用日期，返回 true 表示禁用
+     */
+    disabledDate?: (current: dayjs.Dayjs) => boolean
   }
 
   export type List<T> = Array<T>
@@ -88,6 +93,11 @@ export interface AtCalendarPropsBase {
   minDate?: Calendar.DateArg
 
   maxDate?: Calendar.DateArg
+
+  /**
+   * 自定义禁用日期；传入 dayjs 实例，返回 true 表示该日不可选
+   */
+  disabledDate?: (current: dayjs.Dayjs) => boolean
 
   isSwiper?: boolean
 
@@ -199,6 +209,8 @@ export interface AtCalendarBodyProps {
   minDate?: Calendar.DateArg
 
   maxDate?: Calendar.DateArg
+
+  disabledDate?: (current: dayjs.Dayjs) => boolean
 
   isVertical: boolean
 

--- a/packages/taro-ui/types/checkbox.d.ts
+++ b/packages/taro-ui/types/checkbox.d.ts
@@ -16,7 +16,12 @@ export interface AtCheckboxProps<T> extends AtComponent {
 
   selectedList: Array<T>
 
-  onChange: (selectedList: Array<T>) => void
+  /**
+   * 选中项变化时触发
+   * @param selectedList 当前选中的 value 列表
+   * @param changedValue 本次点击变更的 option value
+   */
+  onChange: (selectedList: Array<T>, changedValue?: T) => void
 }
 
 declare const AtCheckbox: ComponentClass<AtCheckboxProps<any>>

--- a/packages/taro-ui/types/float-layout.d.ts
+++ b/packages/taro-ui/types/float-layout.d.ts
@@ -46,6 +46,16 @@ export interface AtFloatLayoutProps extends AtComponent {
    */
   scrollWithAnimation?: boolean
   /**
+   * 点击浮层的时候时候自动关闭
+   * @default true
+   */
+  closeOnClickOverlay?: boolean
+  /**
+   * 弹出位置
+   * @default 'bottom'
+   */
+  position?: 'top' | 'bottom'
+  /**
    * 元素被关闭时候触发的事件
    */
   onClose?: CommonEventFunction

--- a/packages/taro-ui/types/input-number.d.ts
+++ b/packages/taro-ui/types/input-number.d.ts
@@ -68,6 +68,11 @@ export interface AtInputNumberProps extends AtComponent {
    */
   disabledInput?: boolean
   /**
+   * 是否在失焦时才触发 onChange（输入过程中不触发；加减按钮仍立即 onChange）
+   * @default false
+   */
+  changeOnBlur?: boolean
+  /**
    * 输入框值改变时触发的事件
    * @param {number} value 输入框当前值
    * @description 开发者需要通过 onChange 事件来更新 value 值变化，onChange 函数必填


### PR DESCRIPTION
## Summary

Implements the actionable items from the historical PR inventory ([#1907](https://github.com/jd-opensource/taro-ui/issues/1907)), based on re-evaluation after bulk-closing stale PRs.

| Issue | Change |
|-------|--------|
| #1908 | `AtIcon` `onClick` receives the real event (not `arguments`) |
| #1909 | Ship `.at-frozen` in package styles for H5 scroll lock |
| #1910 | Accordion: avoid `height: 0` flash when default `open` |
| #1911 | Drawer mask: `catchMove` + stop touch propagation |
| #1912 | `AtInputNumber` optional `changeOnBlur` (default behavior unchanged) |
| #1913 / #1914 | Checkbox click by option/value; `onChange(list, changedValue)` |
| #1915 / #1916 | FloatLayout `closeOnClickOverlay` + `position: 'top' \| 'bottom'` |
| #1917 / #1918 | Calendar `disabledDate`; multi-select range cannot span disabled days |

**Out of scope (already closed as not planned):** platform/quickapp/deps/old build PRs, Modal slide popup (#1919).

**Partial note:** Calendar “custom cell render” from old #633 is **not** included; only disabled-range multi-select + `disabledDate`.

## Test plan

- [x] Unit tests: icon, checkbox, float-layout, accordion, drawer, input-number, calendar-related suites
- [x] `pnpm run build` in `packages/taro-ui`
- [ ] Review API docs / demo pages if needed after merge

## Related

- Parent: #1907
- Maintenance: #1905